### PR TITLE
bits.hpp: Avoid warning about unused parameter

### DIFF
--- a/include/mango/core/bits.hpp
+++ b/include/mango/core/bits.hpp
@@ -525,7 +525,7 @@ namespace mango
         return (value << (to - from)) | (value >> (from * 2 - to));
     }
 
-    constexpr s64 s64_extend(s64 value, int from, int to)
+    constexpr s64 s64_extend(s64 value, int from, int /*to*/)
     {
         // sign-extend "from" bits to full s64
         return value | (value & (1ull << (from - 1)) ? ~((1ull << from) - 1) : 0);


### PR DESCRIPTION
`to` is unused in function `s64_extend`, which will usually result in a compiler warning when including this file. This pull request proposes to comment out the parameter name to silence the warning. Another option would be to remove the parameter entirely.