### PR TITLE
X11 / meson fixes

### DIFF
--- a/include/mango/opengl/opengl.hpp
+++ b/include/mango/opengl/opengl.hpp
@@ -12,7 +12,7 @@
 // OpenGL API
 // -----------------------------------------------------------------------
 
-//#define MANGO_OPENGL_DISABLE_API
+//#define MANGO_OPENGL_DISABLE_PLATFORM_API
 
 //#define MANGO_OPENGL_LEGACY_PROFILE
 //#define MANGO_OPENGL_CORE_PROFILE
@@ -36,7 +36,7 @@
         #include "func/glext.hpp"
     #endif
 
-    #ifndef MANGO_OPENGL_DISABLE_API
+    #ifndef MANGO_OPENGL_DISABLE_PLATFORM_API
         #include "khronos/GL/wgl.h"
         #include "khronos/GL/wglext.h"
         #include "func/wglext.hpp"
@@ -76,7 +76,7 @@
     //#include <OpenGLES/ES1/gl.h>
     //#include <OpenGLES/ES1/glext.h>
 
-	// TODO: EGL context
+    // TODO: EGL context
 
 #elif defined(MANGO_PLATFORM_ANDROID)
 
@@ -91,7 +91,7 @@
     //#include <GLES2/gl2.h>
     #include <GLES3/gl3.h>
 
-	// TODO: EGL context
+    // TODO: EGL context
 
 #elif defined(MANGO_PLATFORM_UNIX)
 
@@ -110,19 +110,21 @@
         #include <GL/glext.h>
     #endif
 
-    #ifndef MANGO_OPENGL_DISABLE_API
+    #ifndef MANGO_OPENGL_DISABLE_PLATFORM_API
         #define GLX_GLXEXT_PROTOTYPES
         #include <GL/glx.h>
         #include <GL/glxext.h>
+        #if defined (Status)
+        #undef Status
+            typedef int Status;
+        #endif
     #endif
 
 #else
 
-	//#error "Unsupported OpenGL implementation."
+    //#error "Unsupported OpenGL implementation."
 
 #endif
-
-#ifndef MANGO_OPENGL_DISABLE_API
 
 #include "../image/compression.hpp"
 #include "../window/window.hpp"
@@ -147,9 +149,9 @@ namespace opengl {
         u32 samples  = 1;
     };
 
-	// -------------------------------------------------------------------
-	// Context
-	// -------------------------------------------------------------------
+    // -------------------------------------------------------------------
+    // Context
+    // -------------------------------------------------------------------
 
     class Context : public Window
     {
@@ -175,9 +177,9 @@ namespace opengl {
         int2 getWindowSize() const override;
     };
 
-	// -------------------------------------------------------------------
-	// glext
-	// -------------------------------------------------------------------
+    // -------------------------------------------------------------------
+    // glext
+    // -------------------------------------------------------------------
 
     struct glExtensionMask
     {
@@ -210,9 +212,26 @@ namespace opengl {
 
     extern coreExtensionMask core;
 
-	// -------------------------------------------------------------------
-	// wglext
-	// -------------------------------------------------------------------
+    // -------------------------------------------------------------------
+    // helper functions ; require active context
+    // -------------------------------------------------------------------
+
+    struct InternalFormat
+    {
+        GLenum internal_format;
+        Format format;
+        bool srgb;
+        const char* name;
+    };
+
+    bool isCompressedTextureSupported(TextureCompression compression);
+    const InternalFormat* getInternalFormat(GLenum internalFormat);
+
+#ifndef MANGO_OPENGL_DISABLE_PLATFORM_API
+
+    // -------------------------------------------------------------------
+    // wglext
+    // -------------------------------------------------------------------
 
 #ifdef MANGO_OPENGL_CONTEXT_WGL
 
@@ -227,9 +246,9 @@ namespace opengl {
 
 #endif
 
-	// -------------------------------------------------------------------
-	// glxext
-	// -------------------------------------------------------------------
+    // -------------------------------------------------------------------
+    // glxext
+    // -------------------------------------------------------------------
 
 #ifdef MANGO_OPENGL_CONTEXT_GLX
 
@@ -242,24 +261,9 @@ namespace opengl {
 
     extern glxExtensionMask glxext;
 
-#endif
+#endif // MANGO_OPENGL_CONTEXT_GLX
 
-	// -------------------------------------------------------------------
-    // helper functions ; require active context
-	// -------------------------------------------------------------------
-
-    struct InternalFormat
-    {
-        GLenum internal_format;
-        Format format;
-        bool srgb;
-        const char* name;
-    };
-
-    bool isCompressedTextureSupported(TextureCompression compression);
-    const InternalFormat* getInternalFormat(GLenum internalFormat);
+#endif // MANGO_OPENGL_DISABLE_PLATFORM_API
 
 } // namespace opengl
 } // namespace mango
-
-#endif // MANGO_OPENGL_DISABLE_API

--- a/meson.build
+++ b/meson.build
@@ -26,16 +26,16 @@ enable_bmi       = get_option('enable_bmi')
 enable_bmi2      = get_option('enable_bmi2')
 enable_fma       = get_option('enable_fma')
 
-# for public arguments
-mango_cpp_args = []
+mango_public_cpp_args = []
+mango_interface_cpp_args = [ '-DMANGO_OPENGL_DISABLE_PLATFORM_API' ]
 if get_option('mango_disable_license_gpl')
-    mango_cpp_args =+ [ '-DMANGO_OPENGL_CORE_PROFILE' ]
+    mango_public_cpp_args =+ [ '-DMANGO_OPENGL_CORE_PROFILE' ]
 endif
 
 mango_all_archive_formats = [ 'ZIP', 'RAR', 'MGX' ]
 foreach archive_format : mango_all_archive_formats
     if get_option('mango_disable_archive_@0@'.format(archive_format))
-        mango_cpp_args += [ '-DMANGO_DISABLE_ARCHIVE_@0@'.format(archive_format) ]
+        mango_public_cpp_args += [ '-DMANGO_DISABLE_ARCHIVE_@0@'.format(archive_format) ]
     endif
 endforeach
 
@@ -43,12 +43,12 @@ mango_all_image_formats = [ 'ASTC', 'ATARI', 'BMP', 'C64', 'DDS', 'GIF', 'HDR', 
                             'PCX', 'PKM', 'PNG', 'PNM', 'PVR', 'SGI', 'TGA', 'WEBP', 'ZPNG' ]
 foreach image_format : mango_all_image_formats
     if get_option('mango_disable_image_@0@'.format(image_format))
-        mango_cpp_args += [ '-DMANGO_DISABLE_IMAGE_@0@'.format(image_format) ]
+        mango_public_cpp_args += [ '-DMANGO_DISABLE_IMAGE_@0@'.format(image_format) ]
     endif
 endforeach
 
 if get_option('mango_disable_license_gpl')
-    mango_cpp_args += [ '-DMANGO_DISABLE_LICENSE_GPL' ]
+    mango_public_cpp_args += [ '-DMANGO_DISABLE_LICENSE_GPL' ]
 endif
 
 # ------------------------------------------------------------------------------
@@ -163,7 +163,6 @@ mango_headers = files(
     'include/mango/opengl/khronos/GLES3/gl32.h',
     'include/mango/opengl/khronos/GLES3/gl3platform.h',
     'include/mango/opengl/khronos/KHR/khrplatform.h',
-    'include/mango/opengl/opengl_api.hpp',
     'include/mango/opengl/opengl.hpp',
     'include/mango/simd/altivec_convert.hpp',
     'include/mango/simd/altivec_double128.hpp',
@@ -896,10 +895,13 @@ if host_machine.system() != 'windows'
     mango_deps += [ dl_dep ]
 endif
 
-# if host_machine.system() == 'linux'
-#     x11_dep = cpp.find_library('X11', required : true)
-#     mango_opengl_deps += [ x11_dep ]
-# endif
+if host_machine.system() == 'linux'
+    m_dep = cpp.find_library('m', required : true)
+    x11_dep = cpp.find_library('X11', required : true)
+    mango_deps += [ m_dep ]
+    mango_public_deps += [ m_dep ]
+    mango_opengl_deps += [ x11_dep ]
+endif
 
 mango_inc = include_directories('include')
 
@@ -931,14 +933,14 @@ mango = static_library('mango',
     ],
     include_directories : [ mango_inc, 'source/external/libwebp' ],
     dependencies        : mango_deps,
-    cpp_args            : mango_cpp_args
+    cpp_args            : mango_public_cpp_args
 )
 
 mango_dep = declare_dependency(
     link_with           : mango,
     include_directories : mango_inc,
     dependencies        : mango_public_deps,
-    compile_args        : mango_cpp_args
+    compile_args        : mango_public_cpp_args + mango_interface_cpp_args
 )
 
 mango_framebuffer_deps += [ mango_dep ]
@@ -946,7 +948,7 @@ mango_framebuffer = static_library('mango-framebuffer',
     sources             : window_sources + framebuffer_sources,
     dependencies        : mango_framebuffer_deps,
     include_directories : mango_inc,
-    cpp_args            : mango_cpp_args
+    cpp_args            : mango_public_cpp_args
 )
 
 mango_opengl = static_library('mango-opengl',
@@ -954,13 +956,13 @@ mango_opengl = static_library('mango-opengl',
     link_with           : mango_framebuffer,
     dependencies        : mango_opengl_deps,
     include_directories : mango_inc,
-    cpp_args            : mango_cpp_args
+    cpp_args            : mango_public_cpp_args
 )
 
 mango_opengl_dep = declare_dependency(
     link_with           : mango_opengl,
     include_directories : mango_inc,
-    compile_args        : mango_cpp_args
+    compile_args        : mango_public_cpp_args + mango_interface_cpp_args
 )
 
 mango_vulkan = static_library('mango-vulkan',

--- a/source/mango/window/xlib/xlib_handle.hpp
+++ b/source/mango/window/xlib/xlib_handle.hpp
@@ -15,6 +15,11 @@
 #include <X11/Xutil.h>
 #include <X11/XKBlib.h>
 
+#if defined (Status)
+# undef Status
+typedef int Status;
+#endif
+
 namespace mango
 {
 


### PR DESCRIPTION
Rename MANGO_OPENGL_DISABLE_API -> MANGO_OPENGL_DISABLE_PLATFORM_API
Only hide WGL / GLX with the define, keep Context exposed.
Work around Xlib.h Status #define.
Fix meson build for linux.