### PR TITLE
fix shadow var, bad compile option, guard define

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -321,7 +321,6 @@ endif ()
 # ------------------------------------------------------------------------------
 
 if (COMPILER_MSVC)
-    target_compile_options(mango PUBLIC "/Gm")
     target_compile_options(mango PUBLIC "/DUNICODE")
 
     if (ENABLE_FAST_MATH)

--- a/include/mango/core/configure.hpp
+++ b/include/mango/core/configure.hpp
@@ -185,7 +185,9 @@
 	#endif
 
     // Fix <cmath> macros
-    #define _USE_MATH_DEFINES
+    #ifndef _USE_MATH_DEFINES
+        #define _USE_MATH_DEFINES
+    #endif
 
     // SSE2 is always supported on x64
     #if defined(_M_X64) || defined(_M_AMD64)

--- a/include/mango/core/half.hpp
+++ b/include/mango/core/half.hpp
@@ -149,7 +149,7 @@ namespace mango
             u32 result = 0;
 
             Float temp = value;
-            u32 sign = temp.sign;
+            u32 vsign = temp.sign;
             temp.sign = 0;
 
             if (temp.exponent == (1 << Float::EXPONENT) - 1)
@@ -176,7 +176,7 @@ namespace mango
                 result = temp.u >> (Float::MANTISSA - Mantissa);
             }
 
-            result |= ((sign & Sign) << (Exponent + Mantissa));
+            result |= ((vsign & Sign) << (Exponent + Mantissa));
 
             return result;
         }


### PR DESCRIPTION
Includes three proposed changes

1. Fixed a shadowed variable (local var named the same as class member var). Easy fix.
2. Removed the deprecated (and never fully worked correctly) MSVC compiler option `/Gm`. "/Gm is deprecated. It may not trigger a build for certain kinds of header file changes." https://docs.microsoft.com/en-us/cpp/build/reference/gm-enable-minimal-rebuild?view=vs-2019
3. Put a guard around math define, so that it won't conflict when that is already defined. This double definition can easily happen when libraries like Mango are included in projects. Easy fix.