### PR TITLE
Support decoding of Apple's pngcrunch iphone optimized PNGs.

### DIFF
--- a/include/mango/image/decoder.hpp
+++ b/include/mango/image/decoder.hpp
@@ -23,6 +23,7 @@ namespace mango
         int     levels = 0;  // mipmap levels
         int     faces = 0;   // cubemap faces
         bool    palette = false; // palette is available
+        bool    premultiplied = false; // alpha is premultiplied
         Format  format; // preferred format (fastest available "direct" decoding is possible)
         TextureCompression compression = TextureCompression::NONE;
     };

--- a/source/mango/image/image_png.cpp
+++ b/source/mango/image/image_png.cpp
@@ -1417,6 +1417,7 @@ namespace
             m_header.faces   = 0;
 			m_header.palette = false;
             m_header.compression = TextureCompression::NONE;
+            m_header.premultiplied = m_iphoneOptimized; // apple pngcrush premultiplies alpha
 
             // force alpha channel on when transparency is enabled
             int color_type = m_color_type;


### PR DESCRIPTION
Added decoding of Apple's pngcrush files based on https://iphonedevwiki.net/index.php/CgBI_file_format

With Xcode, you can create such png files manually by running `xcrun pngcrush -iphone image.png image-iphone.png`

Apple premultiplies the pixel data, which I chose not to restore, instead I added a premultiplied flag for header.  Having that support in Format class might be a better idea, but it was too much for me.

There's also `iDOT` chunk that allows Apple to deflate with two threads, but I didn't add it, since to me it seems like marginal win and possible file corruption aspect: https://www.hackerfactor.com/blog/index.php?/archives/895-Connecting-the-iDOTs.html