### PR TITLE
fix broken signature check when compiling for x86

### DIFF
--- a/include/mango/simd/scalar_128_int.hpp
+++ b/include/mango/simd/scalar_128_int.hpp
@@ -42,7 +42,7 @@ namespace mango::simd
         u8 s0, u8 s1, u8 s2, u8 s3, u8 s4, u8 s5, u8 s6, u8 s7,
         u8 s8, u8 s9, u8 s10, u8 s11, u8 s12, u8 s13, u8 s14, u8 s15)
     {
-        return {{ s0, s1, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15 }};
+        return {{ s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15 }};
     }
 
     static inline u8x16 u8x16_uload(const void* source)


### PR DESCRIPTION
In Visual Studio, when compiling for x86, one of the arguments to the function `u8x16_set` in scalar_128_int.hpp (named `s2`) is missing in the returned initializer list. This causes the image decoder to fail to recognize the JPEG signature (and possibly others,) because it will be missing the third character of the string. This fix adds the missing argument.