### PR TITLE
Rename simd set parameters to not overlap with s8, s16 and s32.

### DIFF
--- a/include/mango/simd/altivec_128_int.hpp
+++ b/include/mango/simd/altivec_128_int.hpp
@@ -38,10 +38,11 @@ namespace mango::simd
     }
 
     static inline u8x16 u8x16_set(
-        u8 v0, u8 v1, u8 v2, u8 v3, u8 v4, u8 v5, u8 v6, u8 v7,
-        u8 v8, u8 v9, u8 v10, u8 v11, u8 v12, u8 v13, u8 v14, u8 v15)
+        u8 v00, u8 v01, u8 v02, u8 v03, u8 v04, u8 v05, u8 v06, u8 v07,
+        u8 v08, u8 v09, u8 v10, u8 v11, u8 v12, u8 v13, u8 v14, u8 v15)
     {
-        return (u8x16::vector) { v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15 };
+        return (u8x16::vector) { v00, v01, v02, v03, v04, v05, v06, v07,
+                                 v08, v09, v10, v11, v12, v13, v14, v15 };
     }
 
     static inline u8x16 u8x16_uload(const void* source)
@@ -228,9 +229,9 @@ namespace mango::simd
         return vec_splats(s);
     }
 
-    static inline u16x8 u16x8_set(u16 s0, u16 s1, u16 s2, u16 s3, u16 s4, u16 s5, u16 s6, u16 s7)
+    static inline u16x8 u16x8_set(u16 v0, u16 v1, u16 v2, u16 v3, u16 v4, u16 v5, u16 v6, u16 v7)
     {
-        return (u16x8::vector) { s0, s1, s2, s3, s4, s5, s6, s7 };
+        return (u16x8::vector) { v0, v1, v2, v3, v4, v5, v6, v7 };
     }
 
     static inline u16x8 u16x8_uload(const void* source)
@@ -926,10 +927,11 @@ namespace mango::simd
     }
 
     static inline s8x16 s8x16_set(
-        s8 v0, s8 v1, s8 v2, s8 v3, s8 v4, s8 v5, s8 v6, s8 v7,
-        s8 v8, s8 v9, s8 v10, s8 v11, s8 v12, s8 v13, s8 v14, s8 v15)
+        s8 v00, s8 v01, s8 v02, s8 v03, s8 v04, s8 v05, s8 v06, s8 v07,
+        s8 v08, s8 v09, s8 v10, s8 v11, s8 v12, s8 v13, s8 v14, s8 v15)
     {
-        return (s8x16::vector) { v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15 };
+        return (s8x16::vector) { v00, v01, v02, v03, v04, v05, v06, v07,
+                                 v08, v09, v10, v11, v12, v13, v14, v15 };
     }
 
     static inline s8x16 s8x16_uload(const void* source)
@@ -1126,9 +1128,9 @@ namespace mango::simd
         return vec_splats(s);
     }
 
-    static inline s16x8 s16x8_set(s16 s0, s16 s1, s16 s2, s16 s3, s16 s4, s16 s5, s16 s6, s16 s7)
+    static inline s16x8 s16x8_set(s16 v0, s16 v1, s16 v2, s16 v3, s16 v4, s16 v5, s16 v6, s16 v7)
     {
-        return (s16x8::vector) { s0, s1, s2, s3, s4, s5, s6, s7 };
+        return (s16x8::vector) { v0, v1, v2, v3, v4, v5, v6, v7 };
     }
 
     static inline s16x8 s16x8_uload(const void* source)

--- a/include/mango/simd/avx2_256_int.hpp
+++ b/include/mango/simd/avx2_256_int.hpp
@@ -80,14 +80,14 @@ namespace mango::simd
     }
 
     static inline u8x32 u8x32_set(
-        u8 s00, u8 s01, u8 s02, u8 s03, u8 s04, u8 s05, u8 s06, u8 s07, 
-        u8 s08, u8 s09, u8 s10, u8 s11, u8 s12, u8 s13, u8 s14, u8 s15,
-        u8 s16, u8 s17, u8 s18, u8 s19, u8 s20, u8 s21, u8 s22, u8 s23, 
-        u8 s24, u8 s25, u8 s26, u8 s27, u8 s28, u8 s29, u8 s30, u8 s31)
+        u8 v00, u8 v01, u8 v02, u8 v03, u8 v04, u8 v05, u8 v06, u8 v07,
+        u8 v08, u8 v09, u8 v10, u8 v11, u8 v12, u8 v13, u8 v14, u8 v15,
+        u8 v16, u8 v17, u8 v18, u8 v19, u8 v20, u8 v21, u8 v22, u8 v23,
+        u8 v24, u8 v25, u8 v26, u8 v27, u8 v28, u8 v29, u8 v30, u8 v31)
     {
         return _mm256_set_epi8(
-            s00, s01, s02, s03, s04, s05, s06, s07, s08, s09, s10, s11, s12, s13, s14, s15, 
-            s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31);
+            v00, v01, v02, v03, v04, v05, v06, v07, v08, v09, v10, v11, v12, v13, v14, v15,
+            v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31);
     }
 
     static inline u8x32 u8x32_uload(const void* source)
@@ -250,12 +250,11 @@ namespace mango::simd
     }
 
     static inline u16x16 u16x16_set(
-        u16 s00, u16 s01, u16 s02, u16 s03, u16 s04, u16 s05, u16 s06, u16 s07,
-        u16 s08, u16 s09, u16 s10, u16 s11, u16 s12, u16 s13, u16 s14, u16 s15)
+        u16 v00, u16 v01, u16 v02, u16 v03, u16 v04, u16 v05, u16 v06, u16 v07,
+        u16 v08, u16 v09, u16 v10, u16 v11, u16 v12, u16 v13, u16 v14, u16 v15)
     {
-        return _mm256_set_epi16(
-            s00, s01, s02, s03, s04, s05, s06, s07, 
-            s08, s09, s10, s11, s12, s13, s14, s15);
+        return _mm256_set_epi16(v00, v01, v02, v03, v04, v05, v06, v07,
+                                v08, v09, v10, v11, v12, v13, v14, v15);
     }
 
     static inline u16x16 u16x16_uload(const void* source)
@@ -459,9 +458,9 @@ namespace mango::simd
         return _mm256_set1_epi32(s);
     }
 
-    static inline u32x8 u32x8_set(u32 s0, u32 s1, u32 s2, u32 s3, u32 s4, u32 s5, u32 s6, u32 s7)
+    static inline u32x8 u32x8_set(u32 v0, u32 v1, u32 v2, u32 v3, u32 v4, u32 v5, u32 v6, u32 v7)
     {
-        return _mm256_setr_epi32(s0, s1, s2, s3, s4, s5, s6, s7);
+        return _mm256_setr_epi32(v0, v1, v2, v3, v4, v5, v6, v7);
     }
 
     static inline u32x8 u32x8_uload(const void* source)
@@ -869,14 +868,14 @@ namespace mango::simd
     }
 
     static inline s8x32 s8x32_set(
-        s8 s00, s8 s01, s8 s02, s8 s03, s8 s04, s8 s05, s8 s06, s8 s07, 
-        s8 s08, s8 s09, s8 s10, s8 s11, s8 s12, s8 s13, s8 s14, s8 s15,
-        s8 s16, s8 s17, s8 s18, s8 s19, s8 s20, s8 s21, s8 s22, s8 s23, 
-        s8 s24, s8 s25, s8 s26, s8 s27, s8 s28, s8 s29, s8 s30, s8 s31)
+        s8 v00, s8 v01, s8 v02, s8 v03, s8 v04, s8 v05, s8 v06, s8 v07,
+        s8 v08, s8 v09, s8 v10, s8 v11, s8 v12, s8 v13, s8 v14, s8 v15,
+        s8 v16, s8 v17, s8 v18, s8 v19, s8 v20, s8 v21, s8 v22, s8 v23,
+        s8 v24, s8 v25, s8 v26, s8 v27, s8 v28, s8 v29, s8 v30, s8 v31)
     {
         return _mm256_set_epi8(
-            s00, s01, s02, s03, s04, s05, s06, s07, s08, s09, s10, s11, s12, s13, s14, s15, 
-            s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31);
+            v00, v01, v02, v03, v04, v05, v06, v07, v08, v09, v10, v11, v12, v13, v14, v15,
+            v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31);
     }
 
     static inline s8x32 s8x32_uload(const void* source)
@@ -1040,12 +1039,11 @@ namespace mango::simd
     }
 
     static inline s16x16 s16x16_set(
-        s16 s00, s16 s01, s16 s02, s16 s03, s16 s04, s16 s05, s16 s06, s16 s07,
-        s16 s08, s16 s09, s16 s10, s16 s11, s16 s12, s16 s13, s16 s14, s16 s15)
+        s16 v00, s16 v01, s16 v02, s16 v03, s16 v04, s16 v05, s16 v06, s16 v07,
+        s16 v08, s16 v09, s16 v10, s16 v11, s16 v12, s16 v13, s16 v14, s16 v15)
     {
-        return _mm256_set_epi16(
-            s00, s01, s02, s03, s04, s05, s06, s07, 
-            s08, s09, s10, s11, s12, s13, s14, s15);
+        return _mm256_set_epi16(v00, v01, v02, v03, v04, v05, v06, v07,
+                                v08, v09, v10, v11, v12, v13, v14, v15);
     }
 
     static inline s16x16 s16x16_uload(const void* source)
@@ -1275,9 +1273,9 @@ namespace mango::simd
         return _mm256_set1_epi32(s);
     }
 
-    static inline s32x8 s32x8_set(s32 s0, s32 s1, s32 s2, s32 s3, s32 s4, s32 s5, s32 s6, s32 s7)
+    static inline s32x8 s32x8_set(s32 v0, s32 v1, s32 v2, s32 v3, s32 v4, s32 v5, s32 v6, s32 v7)
     {
-        return _mm256_setr_epi32(s0, s1, s2, s3, s4, s5, s6, s7);
+        return _mm256_setr_epi32(v0, v1, v2, v3, v4, v5, v6, v7);
     }
 
     static inline s32x8 s32x8_uload(const void* source)

--- a/include/mango/simd/avx512_128_int.hpp
+++ b/include/mango/simd/avx512_128_int.hpp
@@ -87,10 +87,11 @@ namespace mango::simd
     }
 
     static inline u8x16 u8x16_set(
-        u8 s0, u8 s1, u8 s2, u8 s3, u8 s4, u8 s5, u8 s6, u8 s7,
-        u8 s8, u8 s9, u8 s10, u8 s11, u8 s12, u8 s13, u8 s14, u8 s15)
+        u8 v00, u8 v01, u8 v02, u8 v03, u8 v04, u8 v05, u8 v06, u8 v07,
+        u8 v08, u8 v09, u8 v10, u8 v11, u8 v12, u8 v13, u8 v14, u8 v15)
     {
-        return _mm_setr_epi8(s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15);
+        return _mm_setr_epi8(v00, v01, v02, v03, v04, v05, v06, v07,
+                             v08, v09, v10, v11, v12, v13, v14, v15);
     }
 
     static inline u8x16 u8x16_uload(const void* source)
@@ -310,9 +311,9 @@ namespace mango::simd
         return _mm_set1_epi16(s);
     }
 
-    static inline u16x8 u16x8_set(u16 s0, u16 s1, u16 s2, u16 s3, u16 s4, u16 s5, u16 s6, u16 s7)
+    static inline u16x8 u16x8_set(u16 v0, u16 v1, u16 v2, u16 v3, u16 v4, u16 v5, u16 v6, u16 v7)
     {
-        return _mm_setr_epi16(s0, s1, s2, s3, s4, s5, s6, s7);
+        return _mm_setr_epi16(v0, v1, v2, v3, v4, v5, v6, v7);
     }
 
     static inline u16x8 u16x8_uload(const void* source)
@@ -1091,10 +1092,11 @@ namespace mango::simd
     }
 
     static inline s8x16 s8x16_set(
-        s8 v0, s8 v1, s8 v2, s8 v3, s8 v4, s8 v5, s8 v6, s8 v7,
-        s8 v8, s8 v9, s8 v10, s8 v11, s8 v12, s8 v13, s8 v14, s8 v15)
+        s8 v00, s8 v01, s8 v02, s8 v03, s8 v04, s8 v05, s8 v06, s8 v07,
+        s8 v08, s8 v09, s8 v10, s8 v11, s8 v12, s8 v13, s8 v14, s8 v15)
     {
-        return _mm_setr_epi8(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
+        return _mm_setr_epi8(v00, v01, v02, v03, v04, v05, v06, v07,
+                             v08, v09, v10, v11, v12, v13, v14, v15);
     }
 
     static inline s8x16 s8x16_uload(const void* source)
@@ -1337,9 +1339,9 @@ namespace mango::simd
         return _mm_set1_epi16(s);
     }
 
-    static inline s16x8 s16x8_set(s16 s0, s16 s1, s16 s2, s16 s3, s16 s4, s16 s5, s16 s6, s16 s7)
+    static inline s16x8 s16x8_set(s16 v0, s16 v1, s16 v2, s16 v3, s16 v4, s16 v5, s16 v6, s16 v7)
     {
-        return _mm_setr_epi16(s0, s1, s2, s3, s4, s5, s6, s7);
+        return _mm_setr_epi16(v0, v1, v2, v3, v4, v5, v6, v7);
     }
 
     static inline s16x8 s16x8_uload(const void* source)

--- a/include/mango/simd/avx512_256_int.hpp
+++ b/include/mango/simd/avx512_256_int.hpp
@@ -81,14 +81,14 @@ namespace mango::simd
     }
 
     static inline u8x32 u8x32_set(
-        u8 s00, u8 s01, u8 s02, u8 s03, u8 s04, u8 s05, u8 s06, u8 s07, 
-        u8 s08, u8 s09, u8 s10, u8 s11, u8 s12, u8 s13, u8 s14, u8 s15,
-        u8 s16, u8 s17, u8 s18, u8 s19, u8 s20, u8 s21, u8 s22, u8 s23, 
-        u8 s24, u8 s25, u8 s26, u8 s27, u8 s28, u8 s29, u8 s30, u8 s31)
+        u8 v00, u8 v01, u8 v02, u8 v03, u8 v04, u8 v05, u8 v06, u8 v07,
+        u8 v08, u8 v09, u8 v10, u8 v11, u8 v12, u8 v13, u8 v14, u8 v15,
+        u8 v16, u8 v17, u8 v18, u8 v19, u8 v20, u8 v21, u8 v22, u8 v23,
+        u8 v24, u8 v25, u8 v26, u8 v27, u8 v28, u8 v29, u8 v30, u8 v31)
     {
         return _mm256_set_epi8(
-            s00, s01, s02, s03, s04, s05, s06, s07, s08, s09, s10, s11, s12, s13, s14, s15, 
-            s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31);
+            v00, v01, v02, v03, v04, v05, v06, v07, v08, v09, v10, v11, v12, v13, v14, v15,
+            v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31);
     }
 
     static inline u8x32 u8x32_uload(const void* source)
@@ -299,12 +299,11 @@ namespace mango::simd
     }
 
     static inline u16x16 u16x16_set(
-        u16 s00, u16 s01, u16 s02, u16 s03, u16 s04, u16 s05, u16 s06, u16 s07,
-        u16 s08, u16 s09, u16 s10, u16 s11, u16 s12, u16 s13, u16 s14, u16 s15)
+        u16 v00, u16 v01, u16 v02, u16 v03, u16 v04, u16 v05, u16 v06, u16 v07,
+        u16 v08, u16 v09, u16 v10, u16 v11, u16 v12, u16 v13, u16 v14, u16 v15)
     {
-        return _mm256_set_epi16(
-            s00, s01, s02, s03, s04, s05, s06, s07, 
-            s08, s09, s10, s11, s12, s13, s14, s15);
+        return _mm256_set_epi16(v00, v01, v02, v03, v04, v05, v06, v07,
+                                v08, v09, v10, v11, v12, v13, v14, v15);
     }
 
     static inline u16x16 u16x16_uload(const void* source)
@@ -556,9 +555,9 @@ namespace mango::simd
         return _mm256_set1_epi32(s);
     }
 
-    static inline u32x8 u32x8_set(u32 s0, u32 s1, u32 s2, u32 s3, u32 s4, u32 s5, u32 s6, u32 s7)
+    static inline u32x8 u32x8_set(u32 v0, u32 v1, u32 v2, u32 v3, u32 v4, u32 v5, u32 v6, u32 v7)
     {
-        return _mm256_setr_epi32(s0, s1, s2, s3, s4, s5, s6, s7);
+        return _mm256_setr_epi32(v0, v1, v2, v3, v4, v5, v6, v7);
     }
 
     static inline u32x8 u32x8_uload(const void* source)
@@ -1038,14 +1037,14 @@ namespace mango::simd
     }
 
     static inline s8x32 s8x32_set(
-        s8 s00, s8 s01, s8 s02, s8 s03, s8 s04, s8 s05, s8 s06, s8 s07, 
-        s8 s08, s8 s09, s8 s10, s8 s11, s8 s12, s8 s13, s8 s14, s8 s15,
-        s8 s16, s8 s17, s8 s18, s8 s19, s8 s20, s8 s21, s8 s22, s8 s23, 
-        s8 s24, s8 s25, s8 s26, s8 s27, s8 s28, s8 s29, s8 s30, s8 s31)
+        s8 v00, s8 v01, s8 v02, s8 v03, s8 v04, s8 v05, s8 v06, s8 v07,
+        s8 v08, s8 v09, s8 v10, s8 v11, s8 v12, s8 v13, s8 v14, s8 v15,
+        s8 v16, s8 v17, s8 v18, s8 v19, s8 v20, s8 v21, s8 v22, s8 v23,
+        s8 v24, s8 v25, s8 v26, s8 v27, s8 v28, s8 v29, s8 v30, s8 v31)
     {
         return _mm256_set_epi8(
-            s00, s01, s02, s03, s04, s05, s06, s07, s08, s09, s10, s11, s12, s13, s14, s15, 
-            s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31);
+            v00, v01, v02, v03, v04, v05, v06, v07, v08, v09, v10, v11, v12, v13, v14, v15,
+            v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31);
     }
 
     static inline s8x32 s8x32_uload(const void* source)
@@ -1279,12 +1278,11 @@ namespace mango::simd
     }
 
     static inline s16x16 s16x16_set(
-        s16 s00, s16 s01, s16 s02, s16 s03, s16 s04, s16 s05, s16 s06, s16 s07,
-        s16 s08, s16 s09, s16 s10, s16 s11, s16 s12, s16 s13, s16 s14, s16 s15)
+        s16 v00, s16 v01, s16 v02, s16 v03, s16 v04, s16 v05, s16 v06, s16 v07,
+        s16 v08, s16 v09, s16 v10, s16 v11, s16 v12, s16 v13, s16 v14, s16 v15)
     {
-        return _mm256_set_epi16(
-            s00, s01, s02, s03, s04, s05, s06, s07, 
-            s08, s09, s10, s11, s12, s13, s14, s15);
+        return _mm256_set_epi16(v00, v01, v02, v03, v04, v05, v06, v07,
+                                v08, v09, v10, v11, v12, v13, v14, v15);
     }
 
     static inline s16x16 s16x16_uload(const void* source)
@@ -1594,9 +1592,9 @@ namespace mango::simd
         return _mm256_set1_epi32(s);
     }
 
-    static inline s32x8 s32x8_set(s32 s0, s32 s1, s32 s2, s32 s3, s32 s4, s32 s5, s32 s6, s32 s7)
+    static inline s32x8 s32x8_set(s32 v0, s32 v1, s32 v2, s32 v3, s32 v4, s32 v5, s32 v6, s32 v7)
     {
-        return _mm256_setr_epi32(s0, s1, s2, s3, s4, s5, s6, s7);
+        return _mm256_setr_epi32(v0, v1, v2, v3, v4, v5, v6, v7);
     }
 
     static inline s32x8 s32x8_uload(const void* source)

--- a/include/mango/simd/avx512_512_int.hpp
+++ b/include/mango/simd/avx512_512_int.hpp
@@ -272,14 +272,14 @@ namespace mango::simd
     }
 
     static inline u16x32 u16x32_set(
-        u16 s00, u16 s01, u16 s02, u16 s03, u16 s04, u16 s05, u16 s06, u16 s07, 
-        u16 s08, u16 s09, u16 s10, u16 s11, u16 s12, u16 s13, u16 s14, u16 s15,
-        u16 s16, u16 s17, u16 s18, u16 s19, u16 s20, u16 s21, u16 s22, u16 s23, 
-        u16 s24, u16 s25, u16 s26, u16 s27, u16 s28, u16 s29, u16 s30, u16 s31)
+        u16 v00, u16 v01, u16 v02, u16 v03, u16 v04, u16 v05, u16 v06, u16 v07,
+        u16 v08, u16 v09, u16 v10, u16 v11, u16 v12, u16 v13, u16 v14, u16 v15,
+        u16 v16, u16 v17, u16 v18, u16 v19, u16 v20, u16 v21, u16 v22, u16 v23,
+        u16 v24, u16 v25, u16 v26, u16 v27, u16 v28, u16 v29, u16 v30, u16 v31)
     {
         return _mm512_set_epi16(
-            s00, s01, s02, s03, s04, s05, s06, s07, s08, s09, s10, s11, s12, s13, s14, s15, 
-            s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31);
+            v00, v01, v02, v03, v04, v05, v06, v07, v08, v09, v10, v11, v12, v13, v14, v15,
+            v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31);
     }
 
     static inline u16x32 u16x32_uload(const void* source)
@@ -518,10 +518,11 @@ namespace mango::simd
     }
 
     static inline u32x16 u32x16_set(
-        u32 s0, u32 s1, u32 s2, u32 s3, u32 s4, u32 s5, u32 s6, u32 s7,
-        u32 s8, u32 s9, u32 s10, u32 s11, u32 s12, u32 s13, u32 s14, u32 s15)
+        u32 v00, u32 v01, u32 v02, u32 v03, u32 v04, u32 v05, u32 v06, u32 v07,
+        u32 v08, u32 v09, u32 v10, u32 v11, u32 v12, u32 v13, u32 v14, u32 v15)
     {
-        return _mm512_setr_epi32(s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15);
+        return _mm512_setr_epi32(v00, v01, v02, v03, v04, v05, v06, v07,
+                                 v08, v09, v10, v11, v12, v13, v14, v15);
     }
 
     static inline u32x16 u32x16_uload(const void* source)
@@ -783,9 +784,9 @@ namespace mango::simd
         return _mm512_set1_epi64(s);
     }
 
-    static inline u64x8 u64x8_set(u64 s0, u64 s1, u64 s2, u64 s3, u64 s4, u64 s5, u64 s6, u64 s7)
+    static inline u64x8 u64x8_set(u64 v0, u64 v1, u64 v2, u64 v3, u64 v4, u64 v5, u64 v6, u64 v7)
     {
-        return _mm512_setr_epi64(s0, s1, s2, s3, s4, s5, s6, s7);
+        return _mm512_setr_epi64(v0, v1, v2, v3, v4, v5, v6, v7);
     }
 
     static inline u64x8 u64x8_uload(const void* source)
@@ -1490,10 +1491,11 @@ namespace mango::simd
     }
 
     static inline s32x16 s32x16_set(
-        s32 v0, s32 v1, s32 v2, s32 v3, s32 v4, s32 v5, s32 v6, s32 v7,
-        s32 v8, s32 v9, s32 v10, s32 v11, s32 v12, s32 v13, s32 v14, s32 v15)
+        s32 v00, s32 v01, s32 v02, s32 v03, s32 v04, s32 v05, s32 v06, s32 v07,
+        s32 v08, s32 v09, s32 v10, s32 v11, s32 v12, s32 v13, s32 v14, s32 v15)
     {
-        return _mm512_setr_epi32(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
+        return _mm512_setr_epi32(v00, v01, v02, v03, v04, v05, v06, v07,
+                                 v08, v09, v10, v11, v12, v13, v14, v15);
     }
 
     static inline s32x16 s32x16_uload(const void* source)
@@ -1788,9 +1790,9 @@ namespace mango::simd
         return _mm512_set1_epi64(s);
     }
 
-    static inline s64x8 s64x8_set(s64 s0, s64 s1, s64 s2, s64 s3, s64 s4, s64 s5, s64 s6, s64 s7)
+    static inline s64x8 s64x8_set(s64 v0, s64 v1, s64 v2, s64 v3, s64 v4, s64 v5, s64 v6, s64 v7)
     {
-        return _mm512_setr_epi64(s0, s1, s2, s3, s4, s5, s6, s7);
+        return _mm512_setr_epi64(v0, v1, v2, v3, v4, v5, v6, v7);
     }
 
     static inline s64x8 s64x8_uload(const void* source)

--- a/include/mango/simd/avx_256_int.hpp
+++ b/include/mango/simd/avx_256_int.hpp
@@ -160,14 +160,16 @@ namespace mango::simd
     }
 
     static inline u8x32 u8x32_set(
-        u8 s00, u8 s01, u8 s02, u8 s03, u8 s04, u8 s05, u8 s06, u8 s07, 
-        u8 s08, u8 s09, u8 s10, u8 s11, u8 s12, u8 s13, u8 s14, u8 s15,
-        u8 s16, u8 s17, u8 s18, u8 s19, u8 s20, u8 s21, u8 s22, u8 s23, 
-        u8 s24, u8 s25, u8 s26, u8 s27, u8 s28, u8 s29, u8 s30, u8 s31)
+        u8 v00, u8 v01, u8 v02, u8 v03, u8 v04, u8 v05, u8 v06, u8 v07,
+        u8 v08, u8 v09, u8 v10, u8 v11, u8 v12, u8 v13, u8 v14, u8 v15,
+        u8 v16, u8 v17, u8 v18, u8 v19, u8 v20, u8 v21, u8 v22, u8 v23,
+        u8 v24, u8 v25, u8 v26, u8 v27, u8 v28, u8 v29, u8 v30, u8 v31)
     {
         u8x32 result;
-        result.data[0] = u8x16_set(s00, s01, s02, s03, s04, s05, s06, s07, s08, s09, s10, s11, s12, s13, s14, s15);
-        result.data[1] = u8x16_set(s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31);
+        result.data[0] = u8x16_set(v00, v01, v02, v03, v04, v05, v06, v07,
+                                   v08, v09, v10, v11, v12, v13, v14, v15);
+        result.data[1] = u8x16_set(v16, v17, v18, v19, v20, v21, v22, v23,
+                                   v24, v25, v26, v27, v28, v29, v30, v31);
         return result;
     }
 
@@ -288,12 +290,12 @@ namespace mango::simd
     }
 
     static inline u16x16 u16x16_set(
-        u16 s00, u16 s01, u16 s02, u16 s03, u16 s04, u16 s05, u16 s06, u16 s07,
-        u16 s08, u16 s09, u16 s10, u16 s11, u16 s12, u16 s13, u16 s14, u16 s15)
+        u16 v00, u16 v01, u16 v02, u16 v03, u16 v04, u16 v05, u16 v06, u16 v07,
+        u16 v08, u16 v09, u16 v10, u16 v11, u16 v12, u16 v13, u16 v14, u16 v15)
     {
         u16x16 result;
-        result.data[0] = u16x8_set(s00, s01, s02, s03, s04, s05, s06, s07);
-        result.data[1] = u16x8_set(s08, s09, s10, s11, s12, s13, s14, s15);
+        result.data[0] = u16x8_set(v00, v01, v02, v03, v04, v05, v06, v07);
+        result.data[1] = u16x8_set(v08, v09, v10, v11, v12, v13, v14, v15);
         return result;
     }
 
@@ -469,11 +471,11 @@ namespace mango::simd
         return result;
     }
 
-    static inline u32x8 u32x8_set(u32 s0, u32 s1, u32 s2, u32 s3, u32 s4, u32 s5, u32 s6, u32 s7)
+    static inline u32x8 u32x8_set(u32 v0, u32 v1, u32 v2, u32 v3, u32 v4, u32 v5, u32 v6, u32 v7)
     {
         u32x8 result;
-        result.data[0] = u32x4_set(s0, s1, s2, s3);
-        result.data[1] = u32x4_set(s4, s5, s6, s7);
+        result.data[0] = u32x4_set(v0, v1, v2, v3);
+        result.data[1] = u32x4_set(v4, v5, v6, v7);
         return result;
     }
 
@@ -835,14 +837,16 @@ namespace mango::simd
     }
 
     static inline s8x32 s8x32_set(
-        s8 s00, s8 s01, s8 s02, s8 s03, s8 s04, s8 s05, s8 s06, s8 s07, 
-        s8 s08, s8 s09, s8 s10, s8 s11, s8 s12, s8 s13, s8 s14, s8 s15,
-        s8 s16, s8 s17, s8 s18, s8 s19, s8 s20, s8 s21, s8 s22, s8 s23, 
-        s8 s24, s8 s25, s8 s26, s8 s27, s8 s28, s8 s29, s8 s30, s8 s31)
+        s8 v00, s8 v01, s8 v02, s8 v03, s8 v04, s8 v05, s8 v06, s8 v07,
+        s8 v08, s8 v09, s8 v10, s8 v11, s8 v12, s8 v13, s8 v14, s8 v15,
+        s8 v16, s8 v17, s8 v18, s8 v19, s8 v20, s8 v21, s8 v22, s8 v23,
+        s8 v24, s8 v25, s8 v26, s8 v27, s8 v28, s8 v29, s8 v30, s8 v31)
     {
         s8x32 result;
-        result.data[0] = s8x16_set(s00, s01, s02, s03, s04, s05, s06, s07, s08, s09, s10, s11, s12, s13, s14, s15);
-        result.data[1] = s8x16_set(s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31);
+        result.data[0] = s8x16_set(v00, v01, v02, v03, v04, v05, v06, v07,
+                                   v08, v09, v10, v11, v12, v13, v14, v15);
+        result.data[1] = s8x16_set(v16, v17, v18, v19, v20, v21, v22, v23,
+                                   v24, v25, v26, v27, v28, v29, v30, v31);
         return result;
     }
 
@@ -965,12 +969,12 @@ namespace mango::simd
     }
 
     static inline s16x16 s16x16_set(
-        s16 s00, s16 s01, s16 s02, s16 s03, s16 s04, s16 s05, s16 s06, s16 s07,
-        s16 s08, s16 s09, s16 s10, s16 s11, s16 s12, s16 s13, s16 s14, s16 s15)
+        s16 v00, s16 v01, s16 v02, s16 v03, v16 v04, s16 v05, s16 v06, s16 v07,
+        s16 v08, s16 v09, s16 v10, s16 v11, v16 v12, s16 v13, s16 v14, s16 v15)
     {
         s16x16 result;
-        result.data[0] = s16x8_set(s00, s01, s02, s03, s04, s05, s06, s07);
-        result.data[1] = s16x8_set(s08, s09, s10, s11, s12, s13, s14, s15);
+        result.data[0] = s16x8_set(v00, v01, v02, v03, v04, v05, v06, v07);
+        result.data[1] = s16x8_set(v08, v09, v10, v11, v12, v13, v14, v15);
         return result;
     }
 
@@ -1153,11 +1157,11 @@ namespace mango::simd
         return result;
     }
 
-    static inline s32x8 s32x8_set(s32 s0, s32 s1, s32 s2, s32 s3, s32 s4, s32 s5, s32 s6, s32 s7)
+    static inline s32x8 s32x8_set(s32 v0, s32 v1, s32 v2, s32 v3, s32 v4, s32 v5, s32 v6, s32 v7)
     {
         s32x8 result;
-        result.data[0] = s32x4_set(s0, s1, s2, s3);
-        result.data[1] = s32x4_set(s4, s5, s6, s7);
+        result.data[0] = s32x4_set(v0, v1, v2, v3);
+        result.data[1] = s32x4_set(v4, v5, v6, v7);
         return result;
     }
 

--- a/include/mango/simd/composite_256_int.hpp
+++ b/include/mango/simd/composite_256_int.hpp
@@ -116,14 +116,16 @@ namespace mango::simd
     }
 
     static inline u8x32 u8x32_set(
-        u8 s00, u8 s01, u8 s02, u8 s03, u8 s04, u8 s05, u8 s06, u8 s07,
-        u8 s08, u8 s09, u8 s10, u8 s11, u8 s12, u8 s13, u8 s14, u8 s15,
-        u8 s16, u8 s17, u8 s18, u8 s19, u8 s20, u8 s21, u8 s22, u8 s23,
-        u8 s24, u8 s25, u8 s26, u8 s27, u8 s28, u8 s29, u8 s30, u8 s31)
+        u8 v00, u8 v01, u8 v02, u8 v03, u8 v04, u8 v05, u8 v06, u8 v07,
+        u8 v08, u8 v09, u8 v10, u8 v11, u8 v12, u8 v13, u8 v14, u8 v15,
+        u8 v16, u8 v17, u8 v18, u8 v19, u8 v20, u8 v21, u8 v22, u8 v23,
+        u8 v24, u8 v25, u8 v26, u8 v27, u8 v28, u8 v29, u8 v30, u8 v31)
     {
         u8x32 result;
-        result.data[0] = u8x16_set(s00, s01, s02, s03, s04, s05, s06, s07, s08, s09, s10, s11, s12, s13, s14, s15);
-        result.data[1] = u8x16_set(s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31);
+        result.data[0] = u8x16_set(v00, v01, v02, v03, v04, v05, v06, v07,
+                                   v08, v09, v10, v11, v12, v13, v14, v15);
+        result.data[1] = u8x16_set(v16, v17, v18, v19, v20, v21, v22, v23,
+                                   v24, v25, v26, v27, v28, v29, v30, v31);
         return result;
     }
 
@@ -215,12 +217,12 @@ namespace mango::simd
     }
 
     static inline u16x16 u16x16_set(
-        u16 s00, u16 s01, u16 s02, u16 s03, u16 s04, u16 s05, u16 s06, u16 s07,
-        u16 s08, u16 s09, u16 s10, u16 s11, u16 s12, u16 s13, u16 s14, u16 s15)
+        u16 v00, u16 v01, u16 v02, u16 v03, u16 v04, u16 v05, u16 v06, u16 v07,
+        u16 v08, u16 v09, u16 v10, u16 v11, u16 v12, u16 v13, u16 v14, u16 v15)
     {
         u16x16 result;
-        result.data[0] = u16x8_set(s00, s01, s02, s03, s04, s05, s06, s07);
-        result.data[1] = u16x8_set(s08, s09, s10, s11, s12, s13, s14, s15);
+        result.data[0] = u16x8_set(v00, v01, v02, v03, v04, v05, v06, v07);
+        result.data[1] = u16x8_set(v08, v09, v10, v11, v12, v13, v14, v15);
         return result;
     }
 
@@ -367,11 +369,11 @@ namespace mango::simd
         return result;
     }
 
-    static inline u32x8 u32x8_set(u32 s0, u32 s1, u32 s2, u32 s3, u32 s4, u32 s5, u32 s6, u32 s7)
+    static inline u32x8 u32x8_set(u32 v0, u32 v1, u32 v2, u32 v3, u32 v4, u32 v5, u32 v6, u32 v7)
     {
         u32x8 result;
-        result.data[0] = u32x4_set(s0, s1, s2, s3);
-        result.data[1] = u32x4_set(s4, s5, s6, s7);
+        result.data[0] = u32x4_set(v0, v1, v2, v3);
+        result.data[1] = u32x4_set(v4, v5, v6, v7);
         return result;
     }
 
@@ -671,14 +673,16 @@ namespace mango::simd
     }
 
     static inline s8x32 s8x32_set(
-        s8 s00, s8 s01, s8 s02, s8 s03, s8 s04, s8 s05, s8 s06, s8 s07, 
-        s8 s08, s8 s09, s8 s10, s8 s11, s8 s12, s8 s13, s8 s14, s8 s15,
-        s8 s16, s8 s17, s8 s18, s8 s19, s8 s20, s8 s21, s8 s22, s8 s23, 
-        s8 s24, s8 s25, s8 s26, s8 s27, s8 s28, s8 s29, s8 s30, s8 s31)
+        s8 v00, s8 v01, s8 v02, s8 v03, s8 v04, s8 v05, s8 v06, s8 v07,
+        s8 v08, s8 v09, s8 v10, s8 v11, s8 v12, s8 v13, s8 v14, s8 v15,
+        s8 v16, s8 v17, s8 v18, s8 v19, s8 v20, s8 v21, s8 v22, s8 v23,
+        s8 v24, s8 v25, s8 v26, s8 v27, s8 v28, s8 v29, s8 v30, s8 v31)
     {
         s8x32 result;
-        result.data[0] = s8x16_set(s00, s01, s02, s03, s04, s05, s06, s07, s08, s09, s10, s11, s12, s13, s14, s15);
-        result.data[1] = s8x16_set(s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31);
+        result.data[0] = s8x16_set(v00, v01, v02, v03, v04, v05, v06, v07,
+                                   v08, v09, v10, v11, v12, v13, v14, v15);
+        result.data[1] = s8x16_set(v16, v17, v18, v19, v20, v21, v22, v23,
+                                   v24, v25, v26, v27, v28, v29, v30, v31);
         return result;
     }
 
@@ -774,12 +778,12 @@ namespace mango::simd
     }
 
     static inline s16x16 s16x16_set(
-        s16 s00, s16 s01, s16 s02, s16 s03, s16 s04, s16 s05, s16 s06, s16 s07,
-        s16 s08, s16 s09, s16 s10, s16 s11, s16 s12, s16 s13, s16 s14, s16 s15)
+        s16 v00, s16 v01, s16 v02, s16 v03, s16 v04, s16 v05, s16 v06, s16 v07,
+        s16 v08, s16 v09, s16 v10, s16 v11, s16 v12, s16 v13, s16 v14, s16 v15)
     {
         s16x16 result;
-        result.data[0] = s16x8_set(s00, s01, s02, s03, s04, s05, s06, s07);
-        result.data[1] = s16x8_set(s08, s09, s10, s11, s12, s13, s14, s15);
+        result.data[0] = s16x8_set(v00, v01, v02, v03, v04, v05, v06, v07);
+        result.data[1] = s16x8_set(v08, v09, v10, v11, v12, v13, v14, v15);
         return result;
     }
 
@@ -937,11 +941,11 @@ namespace mango::simd
         return result;
     }
 
-    static inline s32x8 s32x8_set(s32 s0, s32 s1, s32 s2, s32 s3, s32 s4, s32 s5, s32 s6, s32 s7)
+    static inline s32x8 s32x8_set(s32 v0, s32 v1, s32 v2, s32 v3, s32 v4, s32 v5, s32 v6, s32 v7)
     {
         s32x8 result;
-        result.data[0] = s32x4_set(s0, s1, s2, s3);
-        result.data[1] = s32x4_set(s4, s5, s6, s7);
+        result.data[0] = s32x4_set(v0, v1, v2, v3);
+        result.data[1] = s32x4_set(v4, v5, v6, v7);
         return result;
     }
 

--- a/include/mango/simd/composite_512_int.hpp
+++ b/include/mango/simd/composite_512_int.hpp
@@ -103,8 +103,14 @@ namespace mango::simd
         u8 v56, u8 v57, u8 v58, u8 v59, u8 v60, u8 v61, u8 v62, u8 v63)
     {
         u8x64 result;
-        result.data[0] = u8x32_set(v00, v01, v02, v03, v04, v05, v06, v07, v08, v09, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31);
-        result.data[1] = u8x32_set(v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55, v56, v57, v58, v59, v60, v61, v62, v63);
+        result.data[0] = u8x32_set(v00, v01, v02, v03, v04, v05, v06, v07,
+                                   v08, v09, v10, v11, v12, v13, v14, v15,
+                                   v16, v17, v18, v19, v20, v21, v22, v23,
+                                   v24, v25, v26, v27, v28, v29, v30, v31);
+        result.data[1] = u8x32_set(v32, v33, v34, v35, v36, v37, v38, v39,
+                                   v40, v41, v42, v43, v44, v45, v46, v47,
+                                   v48, v49, v50, v51, v52, v53, v54, v55,
+                                   v56, v57, v58, v59, v60, v61, v62, v63);
         return result;
     }
 
@@ -181,14 +187,16 @@ namespace mango::simd
     }
 
     static inline u16x32 u16x32_set(
-        u16 v00, u16 v01, u16 v02, u16 v03, u16 v04, u16 v05, u16 v06, u16 v07, 
+        u16 v00, u16 v01, u16 v02, u16 v03, u16 v04, u16 v05, u16 v06, u16 v07,
         u16 v08, u16 v09, u16 v10, u16 v11, u16 v12, u16 v13, u16 v14, u16 v15,
-        u16 v16, u16 v17, u16 v18, u16 v19, u16 v20, u16 v21, u16 v22, u16 v23, 
+        u16 v16, u16 v17, u16 v18, u16 v19, u16 v20, u16 v21, u16 v22, u16 v23,
         u16 v24, u16 v25, u16 v26, u16 v27, u16 v28, u16 v29, u16 v30, u16 v31)
     {
         u16x32 result;
-        result.data[0] = u16x16_set(v00, v01, v02, v03, v04, v05, v06, v07, v08, v09, v10, v11, v12, v13, v14, v15);
-        result.data[1] = u16x16_set(v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31);
+        result.data[0] = u16x16_set(v00, v01, v02, v03, v04, v05, v06, v07,
+                                    v08, v09, v10, v11, v12, v13, v14, v15);
+        result.data[1] = u16x16_set(v16, v17, v18, v19, v20, v21, v22, v23,
+                                    v24, v25, v26, v27, v28, v29, v30, v31);
         return result;
     }
 
@@ -321,12 +329,12 @@ namespace mango::simd
     }
 
     static inline u32x16 u32x16_set(
-        u32 s0, u32 s1, u32 s2, u32 s3, u32 s4, u32 s5, u32 s6, u32 s7,
-        u32 s8, u32 s9, u32 s10, u32 s11, u32 s12, u32 s13, u32 s14, u32 s15)
+        u32 v00, u32 v01, u32 v02, u32 v03, u32 v04, u32 v05, u32 v06, u32 v07,
+        u32 v08, u32 v09, u32 v10, u32 v11, u32 v12, u32 v13, u32 v14, u32 v15)
     {
         u32x16 result;
-        result.data[0] = u32x8_set(s0, s1, s2, s3, s4, s5, s6, s7);
-        result.data[1] = u32x8_set(s8, s9, s10, s11, s12, s13, s14, s15);
+        result.data[0] = u32x8_set(v00, v01, v02, v03, v04, v05, v06, v07);
+        result.data[1] = u32x8_set(v08, v09, v10, v11, v12, v13, v14, v15);
         return result;
     }
 
@@ -481,11 +489,11 @@ namespace mango::simd
         return result;
     }
 
-    static inline u64x8 u64x8_set(u64 s0, u64 s1, u64 s2, u64 s3, u64 s4, u64 s5, u64 s6, u64 s7)
+    static inline u64x8 u64x8_set(u64 v0, u64 v1, u64 v2, u64 v3, u64 v4, u64 v5, u64 v6, u64 v7)
     {
         u64x8 result;
-        result.data[0] = u64x4_set(s0, s1, s2, s3);
-        result.data[1] = u64x4_set(s4, s5, s6, s7);
+        result.data[0] = u64x4_set(v0, v1, v2, v3);
+        result.data[1] = u64x4_set(v4, v5, v6, v7);
         return result;
     }
 
@@ -603,8 +611,14 @@ namespace mango::simd
         s8 v56, s8 v57, s8 v58, s8 v59, s8 v60, s8 v61, s8 v62, s8 v63)
     {
         s8x64 result;
-        result.data[0] = s8x32_set(v00, v01, v02, v03, v04, v05, v06, v07, v08, v09, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31);
-        result.data[1] = s8x32_set(v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55, v56, v57, v58, v59, v60, v61, v62, v63);
+        result.data[0] = s8x32_set(v00, v01, v02, v03, v04, v05, v06, v07,
+                                   v08, v09, v10, v11, v12, v13, v14, v15,
+                                   v16, v17, v18, v19, v20, v21, v22, v23,
+                                   v24, v25, v26, v27, v28, v29, v30, v31);
+        result.data[1] = s8x32_set(v32, v33, v34, v35, v36, v37, v38, v39,
+                                   v40, v41, v42, v43, v44, v45, v46, v47,
+                                   v48, v49, v50, v51, v52, v53, v54, v55,
+                                   v56, v57, v58, v59, v60, v61, v62, v63);
         return result;
     }
 
@@ -691,8 +705,10 @@ namespace mango::simd
         s16 v24, s16 v25, s16 v26, s16 v27, s16 v28, s16 v29, s16 v30, s16 v31)
     {
         s16x32 result;
-        result.data[0] = s16x16_set(v00, v01, v02, v03, v04, v05, v06, v07, v08, v09, v10, v11, v12, v13, v14, v15);
-        result.data[1] = s16x16_set(v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31);
+        result.data[0] = s16x16_set(v00, v01, v02, v03, v04, v05, v06, v07,
+                                    v08, v09, v10, v11, v12, v13, v14, v15);
+        result.data[1] = s16x16_set(v16, v17, v18, v19, v20, v21, v22, v23,
+                                    v24, v25, v26, v27, v28, v29, v30, v31);
         return result;
     }
 
@@ -832,12 +848,12 @@ namespace mango::simd
     }
 
     static inline s32x16 s32x16_set(
-        s32 v0, s32 v1, s32 v2, s32 v3, s32 v4, s32 v5, s32 v6, s32 v7,
-        s32 v8, s32 v9, s32 v10, s32 v11, s32 v12, s32 v13, s32 v14, s32 v15)
+        s32 v00, s32 v01, s32 v02, s32 v03, s32 v04, s32 v05, s32 v06, s32 v07,
+        s32 v08, s32 v09, s32 v10, s32 v11, s32 v12, s32 v13, s32 v14, s32 v15)
     {
         s32x16 result;
-        result.data[0] = s32x8_set(v0, v1, v2, v3, v4, v5, v6, v7);
-        result.data[1] = s32x8_set(v8, v9, v10, v11, v12, v13, v14, v15);
+        result.data[0] = s32x8_set(v00, v01, v02, v03, v04, v05, v06, v07);
+        result.data[1] = s32x8_set(v08, v09, v10, v11, v12, v13, v14, v15);
         return result;
     }
 
@@ -996,11 +1012,11 @@ namespace mango::simd
         return result;
     }
 
-    static inline s64x8 s64x8_set(s64 s0, s64 s1, s64 s2, s64 s3, s64 s4, s64 s5, s64 s6, s64 s7)
+    static inline s64x8 s64x8_set(s64 v0, s64 v1, s64 v2, s64 v3, s64 v4, s64 v5, s64 v6, s64 v7)
     {
         s64x8 result;
-        result.data[0] = s64x4_set(s0, s1, s2, s3);
-        result.data[1] = s64x4_set(s4, s5, s6, s7);
+        result.data[0] = s64x4_set(v0, v1, v2, v3);
+        result.data[1] = s64x4_set(v4, v5, v6, v7);
         return result;
     }
 

--- a/include/mango/simd/msa_128_int.hpp
+++ b/include/mango/simd/msa_128_int.hpp
@@ -38,10 +38,11 @@ namespace mango::simd
     }
 
     static inline u8x16 u8x16_set(
-        u8 s0, u8 s1, u8 s2, u8 s3, u8 s4, u8 s5, u8 s6, u8 s7,
-        u8 s8, u8 s9, u8 s10, u8 s11, u8 s12, u8 s13, u8 s14, u8 s15)
+        u8 v00, u8 v01, u8 v02, u8 v03, u8 v04, u8 v05, u8 v06, u8 v07,
+        u8 v08, u8 v09, u8 v10, u8 v11, u8 v12, u8 v13, u8 v14, u8 v15)
     {
-        return (v16u8) { s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15 };
+        return (v16u8) { v00, v01, v02, v03, v04, v05, v06, v07,
+                         v08, v09, v10, v11, v12, v13, v14, v15 };
     }
 
     static inline u8x16 u8x16_uload(const void* source)
@@ -206,9 +207,9 @@ namespace mango::simd
         return (v8u16) __msa_fill_h(s);
     }
 
-    static inline u16x8 u16x8_set(u16 s0, u16 s1, u16 s2, u16 s3, u16 s4, u16 s5, u16 s6, u16 s7)
+    static inline u16x8 u16x8_set(u16 v0, u16 v1, u16 v2, u16 v3, u16 v4, u16 v5, u16 v6, u16 v7)
     {
-        return (v8u16) { s0, s1, s2, s3, s4, s5, s6, s7 };
+        return (v8u16) { v0, v1, v2, v3, v4, v5, v6, v7 };
     }
 
     static inline u16x8 u16x8_uload(const void* source)
@@ -835,10 +836,11 @@ namespace mango::simd
     }
 
     static inline s8x16 s8x16_set(
-        s8 v0, s8 v1, s8 v2, s8 v3, s8 v4, s8 v5, s8 v6, s8 v7,
-        s8 v8, s8 v9, s8 v10, s8 v11, s8 v12, s8 v13, s8 v14, s8 v15)
+        s8 v00, s8 v01, s8 v02, s8 v03, s8 v04, s8 v05, s8 v06, s8 v07,
+        s8 v08, s8 v09, s8 v10, s8 v11, s8 v12, s8 v13, s8 v14, s8 v15)
     {
-        return (v16i8) { v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15 };
+        return (v16i8) { v00, v01, v02, v03, v04, v05, v06, v07,
+                         v08, v09, v10, v11, v12, v13, v14, v15 };
     }
 
     static inline s8x16 s8x16_uload(const void* source)
@@ -1014,9 +1016,9 @@ namespace mango::simd
         return __msa_fill_h(s);
     }
 
-    static inline s16x8 s16x8_set(s16 s0, s16 s1, s16 s2, s16 s3, s16 s4, s16 s5, s16 s6, s16 s7)
+    static inline s16x8 s16x8_set(s16 v0, s16 v1, s16 v2, s16 v3, s16 v4, s16 v5, s16 v6, s16 v7)
     {
-        return (v8i16) { s0, s1, s2, s3, s4, s5, s6, s7 };
+        return (v8i16) { v0, v1, v2, v3, v4, v5, v6, v7 };
     }
 
     static inline s16x8 s16x8_uload(const void* source)

--- a/include/mango/simd/neon_128_int.hpp
+++ b/include/mango/simd/neon_128_int.hpp
@@ -38,10 +38,11 @@ namespace mango::simd
     }
 
     static inline u8x16 u8x16_set(
-        u8 s0, u8 s1, u8 s2, u8 s3, u8 s4, u8 s5, u8 s6, u8 s7,
-        u8 s8, u8 s9, u8 s10, u8 s11, u8 s12, u8 s13, u8 s14, u8 s15)
+        u8 v00, u8 v01, u8 v02, u8 v03, u8 v04, u8 v05, u8 v06, u8 v07,
+        u8 v08, u8 v09, u8 v10, u8 v11, u8 v12, u8 v13, u8 v14, u8 v15)
     {
-        uint8x16_t temp = { s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15 };
+        uint8x16_t temp = { v00, v01, v02, v03, v04, v05, v06, v07,
+                            v08, v09, v10, v11, v12, v13, v14, v15 };
         return temp;
     }
 
@@ -222,9 +223,9 @@ namespace mango::simd
         return vdupq_n_u16(s);
     }
 
-    static inline u16x8 u16x8_set(u16 s0, u16 s1, u16 s2, u16 s3, u16 s4, u16 s5, u16 s6, u16 s7)
+    static inline u16x8 u16x8_set(u16 v0, u16 v1, u16 v2, u16 v3, u16 v4, u16 v5, u16 v6, u16 v7)
     {
-        uint16x8_t temp = { s0, s1, s2, s3, s4, s5, s6, s7 };
+        uint16x8_t temp = { v0, v1, v2, v3, v4, v5, v6, v7 };
         return temp;
     }
 
@@ -955,10 +956,11 @@ namespace mango::simd
     }
 
     static inline s8x16 s8x16_set(
-        s8 v0, s8 v1, s8 v2, s8 v3, s8 v4, s8 v5, s8 v6, s8 v7,
-        s8 v8, s8 v9, s8 v10, s8 v11, s8 v12, s8 v13, s8 v14, s8 v15)
+        s8 v00, s8 v01, s8 v02, s8 v03, s8 v04, s8 v05, s8 v06, s8 v07,
+        s8 v08, s8 v09, s8 v10, s8 v11, s8 v12, s8 v13, s8 v14, s8 v15)
     {
-        int8x16_t temp = { v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15 };
+        int8x16_t temp = { v00, v01, v02, v03, v04, v05, v06, v07,
+                           v08, v09, v10, v11, v12, v13, v14, v15 };
         return temp;
     }
 
@@ -1149,9 +1151,9 @@ namespace mango::simd
         return vdupq_n_s16(s);
     }
 
-    static inline s16x8 s16x8_set(s16 s0, s16 s1, s16 s2, s16 s3, s16 s4, s16 s5, s16 s6, s16 s7)
+    static inline s16x8 s16x8_set(s16 v0, s16 v1, s16 v2, s16 v3, s16 v4, s16 v5, s16 v6, s16 v7)
     {
-        int16x8_t temp = { s0, s1, s2, s3, s4, s5, s6, s7 };
+        int16x8_t temp = { v0, v1, v2, v3, v4, v5, v6, v7 };
         return temp;
     }
 

--- a/include/mango/simd/scalar_128_int.hpp
+++ b/include/mango/simd/scalar_128_int.hpp
@@ -39,10 +39,10 @@ namespace mango::simd
     }
 
     static inline u8x16 u8x16_set(
-        u8 s0, u8 s1, u8 s2, u8 s3, u8 s4, u8 s5, u8 s6, u8 s7,
-        u8 s8, u8 s9, u8 s10, u8 s11, u8 s12, u8 s13, u8 s14, u8 s15)
+        u8 v00, u8 v01, u8 v02, u8 v03, u8 v04, u8 v05, u8 v06, u8 v07,
+        u8 v08, u8 v09, u8 v10, u8 v11, u8 v12, u8 v13, u8 v14, u8 v15)
     {
-        return {{ s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15 }};
+        return {{ v00, v01, v02, v03, v04, v05, v06, v07, v08, v09, v10, v11, v12, v13, v14, v15 }};
     }
 
     static inline u8x16 u8x16_uload(const void* source)
@@ -207,9 +207,9 @@ namespace mango::simd
         return detail::scalar_set<u16, 8>(s);
     }
 
-    static inline u16x8 u16x8_set(u16 s0, u16 s1, u16 s2, u16 s3, u16 s4, u16 s5, u16 s6, u16 s7)
+    static inline u16x8 u16x8_set(u16 v0, u16 v1, u16 v2, u16 v3, u16 v4, u16 v5, u16 v6, u16 v7)
     {
-        return {{ s0, s1, s2, s3, s4, s5, s6, s7 }};
+        return {{ v0, v1, v2, v3, v4, v5, v6, v7 }};
     }
 
     static inline u16x8 u16x8_uload(const void* source)
@@ -386,7 +386,7 @@ namespace mango::simd
     {
         return detail::scalar_shift_right<u16x8, s16>(a, count);
     }
-    
+
     // -----------------------------------------------------------------
     // u32x4
     // -----------------------------------------------------------------
@@ -833,10 +833,10 @@ namespace mango::simd
     }
 
     static inline s8x16 s8x16_set(
-        s8 v0, s8 v1, s8 v2, s8 v3, s8 v4, s8 v5, s8 v6, s8 v7,
-        s8 v8, s8 v9, s8 v10, s8 v11, s8 v12, s8 v13, s8 v14, s8 v15)
+        s8 v00, s8 v01, s8 v02, s8 v03, s8 v04, s8 v05, s8 v06, s8 v07,
+        s8 v08, s8 v09, s8 v10, s8 v11, s8 v12, s8 v13, s8 v14, s8 v15)
     {
-        return {{ v0, v1, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15 }};
+        return {{ v00, v01, v02, v03, v04, v05, v06, v07, v08, v09, v10, v11, v12, v13, v14, v15 }};
     }
 
     static inline s8x16 s8x16_uload(const void* source)
@@ -1011,9 +1011,9 @@ namespace mango::simd
         return detail::scalar_set<s16, 8>(s);
     }
 
-    static inline s16x8 s16x8_set(s16 s0, s16 s1, s16 s2, s16 s3, s16 s4, s16 s5, s16 s6, s16 s7)
+    static inline s16x8 s16x8_set(s16 v0, s16 v1, s16 v2, s16 v3, s16 v4, s16 v5, s16 v6, s16 v7)
     {
-        return {{ s0, s1, s2, s3, s4, s5, s6, s7 }};
+        return {{ v0, v1, v2, v3, v4, v5, v6, v7 }};
     }
 
     static inline s16x8 s16x8_uload(const void* source)

--- a/include/mango/simd/sse2_128_int.hpp
+++ b/include/mango/simd/sse2_128_int.hpp
@@ -184,10 +184,11 @@ namespace mango::simd
     }
 
     static inline u8x16 u8x16_set(
-        u8 s0, u8 s1, u8 s2, u8 s3, u8 s4, u8 s5, u8 s6, u8 s7,
-        u8 s8, u8 s9, u8 s10, u8 s11, u8 s12, u8 s13, u8 s14, u8 s15)
+        u8 v00, u8 v01, u8 v02, u8 v03, u8 v04, u8 v05, u8 v06, u8 v07,
+        u8 v08, u8 v09, u8 v10, u8 v11, u8 v12, u8 v13, u8 v14, u8 v15)
     {
-        return _mm_setr_epi8(s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15);
+        return _mm_setr_epi8(v00, v01, v02, v03, v04, v05, v06, v07,
+                             v08, v09, v10, v11, v12, v13, v14, v15);
     }
 
     static inline u8x16 u8x16_uload(const void* source)
@@ -383,9 +384,9 @@ namespace mango::simd
         return _mm_set1_epi16(s);
     }
 
-    static inline u16x8 u16x8_set(u16 s0, u16 s1, u16 s2, u16 s3, u16 s4, u16 s5, u16 s6, u16 s7)
+    static inline u16x8 u16x8_set(u16 v0, u16 v1, u16 v2, u16 v3, u16 v4, u16 v5, u16 v6, u16 v7)
     {
-        return _mm_setr_epi16(s0, s1, s2, s3, s4, s5, s6, s7);
+        return _mm_setr_epi16(v0, v1, v2, v3, v4, v5, v6, v7);
     }
 
     static inline u16x8 u16x8_uload(const void* source)
@@ -1361,10 +1362,11 @@ namespace mango::simd
     }
 
     static inline s8x16 s8x16_set(
-        s8 v0, s8 v1, s8 v2, s8 v3, s8 v4, s8 v5, s8 v6, s8 v7,
-        s8 v8, s8 v9, s8 v10, s8 v11, s8 v12, s8 v13, s8 v14, s8 v15)
+        s8 v00, s8 v01, s8 v02, s8 v03, s8 v04, s8 v05, s8 v06, s8 v07,
+        s8 v08, s8 v09, s8 v10, s8 v11, s8 v12, s8 v13, s8 v14, s8 v15)
     {
-        return _mm_setr_epi8(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
+        return _mm_setr_epi8(v00, v01, v02, v03, v04, v05, v06, v07,
+                             v08, v09, v10, v11, v12, v13, v14, v15);
     }
 
     static inline s8x16 s8x16_uload(const void* source)

--- a/include/mango/simd/wasm_128_int.hpp
+++ b/include/mango/simd/wasm_128_int.hpp
@@ -38,10 +38,11 @@ namespace mango::simd
     }
 
     static inline u8x16 u8x16_set(
-        u8 v0, u8 v1, u8 v2, u8 v3, u8 v4, u8 v5, u8 v6, u8 v7,
-        u8 v8, u8 v9, u8 v10, u8 v11, u8 v12, u8 v13, u8 v14, u8 v15)
+        u8 v00, u8 v01, u8 v02, u8 v03, u8 v04, u8 v05, u8 v06, u8 v07,
+        u8 v08, u8 v09, u8 v10, u8 v11, u8 v12, u8 v13, u8 v14, u8 v15)
     {
-        return wasm_u8x16_make(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
+        return wasm_u8x16_make(v00, v01, v02, v03, v04, v05, v06, v07,
+                               v08, v09, v10, v11, v12, v13, v14, v15);
     }
 
     static inline u8x16 u8x16_uload(const void* source)
@@ -205,9 +206,9 @@ namespace mango::simd
         return wasm_u16x8_splat(s);
     }
 
-    static inline u16x8 u16x8_set(u16 s0, u16 s1, u16 s2, u16 s3, u16 s4, u16 s5, u16 s6, u16 s7)
+    static inline u16x8 u16x8_set(u16 v0, u16 v1, u16 v2, u16 v3, u16 v4, u16 v5, u16 v6, u16 v7)
     {
-        return wasm_u16x8_make(s0, s1, s2, s3, s4, s5, s6, s7);
+        return wasm_u16x8_make(v0, v1, v2, v3, v4, v5, v6, v7);
     }
 
     static inline u16x8 u16x8_uload(const void* source)
@@ -873,10 +874,11 @@ namespace mango::simd
     }
 
     static inline s8x16 s8x16_set(
-        s8 v0, s8 v1, s8 v2, s8 v3, s8 v4, s8 v5, s8 v6, s8 v7,
-        s8 v8, s8 v9, s8 v10, s8 v11, s8 v12, s8 v13, s8 v14, s8 v15)
+        s8 v00, s8 v01, s8 v02, s8 v03, s8 v04, s8 v05, s8 v06, s8 v07,
+        s8 v08, s8 v09, s8 v10, s8 v11, s8 v12, s8 v13, s8 v14, s8 v15)
     {
-        return wasm_i8x16_make(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
+        return wasm_i8x16_make(v00, v01, v02, v03, v04, v05, v06, v07,
+                               v08, v09, v10, v11, v12, v13, v14, v15);
     }
 
     static inline s8x16 s8x16_uload(const void* source)
@@ -1049,9 +1051,9 @@ namespace mango::simd
         return wasm_i16x8_splat(s);
     }
 
-    static inline s16x8 s16x8_set(s16 s0, s16 s1, s16 s2, s16 s3, s16 s4, s16 s5, s16 s6, s16 s7)
+    static inline s16x8 s16x8_set(s16 v0, s16 v1, s16 v2, s16 v3, s16 v4, s16 v5, s16 v6, s16 v7)
     {
-        return wasm_i16x8_make(s0, s1, s2, s3, s4, s5, s6, s7);
+        return wasm_i16x8_make(v0, v1, v2, v3, v4, v5, v6, v7);
     }
 
     static inline s16x8 s16x8_uload(const void* source)


### PR DESCRIPTION
The sN naming worked, until it didn't with a specific compiler so let's fix these once and for all; use v prefix from now on.