### PR TITLE
Check if source is Luminance for blitter

### DIFF
--- a/source/mango/image/blitter.cpp
+++ b/source/mango/image/blitter.cpp
@@ -3244,7 +3244,7 @@ namespace mango::image
             MANGO_EXCEPTION("[Blitter] Indexed formats are not supported.");
         }
 
-        if (dest.isLuminance())
+        if (!source.isLuminance() && dest.isLuminance())
         {
             MANGO_EXCEPTION("[Blitter] RGB to Luminance is not supported.");
         }


### PR DESCRIPTION
I feel like I'm stringing you along at this point so sorry for drawing this one thing out so much, but this is a single line change so I decided to make a PR for this.

It's been established that the blitter cannot be used for conversion from RGB, but it still works perfectly fine to convert between surfaces that are both different luminance formats, so checking if the source is luminance allows it to be used for this functionality. Even for 32-bit inputs, this works because OR is used for all the channels, and the image is grayscale, so all channels will be the same, so when they are OR'd together the number does not go up incorrectly like it would for RGB input.

(I did test this and it works but it's possible one of the SIMD implementations I have disabled breaks this assumption - I am writing this on the assumption they all do the equivalent)