### PR TITLE
Move target_compile_definitions for MANGO_LICENSE_DISABLE_GPL

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -106,10 +106,6 @@ else ()
     message(STATUS "Build: " ${CMAKE_BUILD_TYPE} ", Static")
 endif ()
 
-if (NOT LICENSE_GPL)
-    target_compile_definitions(mango PUBLIC "MANGO_LICENSE_DISABLE_GPL")
-endif ()
-
 # ------------------------------------------------------------------------------
 # source directories
 # ------------------------------------------------------------------------------
@@ -585,6 +581,10 @@ if (LICENSE_GPL)
     # vcpkg: libheif
     find_module_with_pkg(HEIF libheif>=1.13.0)
     find_module_with_cmake(HEIF libheif heif)
+
+else ()
+
+    target_compile_definitions(mango PUBLIC "MANGO_LICENSE_DISABLE_GPL")
 
 endif ()
 


### PR DESCRIPTION
Currently, disabling the `LICENSE_GPL` option in the CMake project always results in the following error:

> Cannot specify compile definitions for target "mango" which is not built by this project.

This error occurs because `target_compile_definitions` for "MANGO_LICENSE_DISABLE_GPL" is called before `add_library`, at which point the mango target is not defined. To solve the error the call to `target_compile_definitions` must occur after `add_library`. I have moved it down to the external libraries section, where there is another check for the same condition and where having this check would not cause any error to occur.