### PR TITLE
Fix Warnings and refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ CMakeCache.txt
 install_manifest.txt
 Makefile
 example/x
+.ninja_deps
+.ninja_log
+build.ninja

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -625,6 +625,7 @@ if (EMSCRIPTEN)
 
 elseif (COMPILER_MSVC)
 
+    #target_compile_options(mango PUBLIC "/Wall")
     target_compile_options(mango PUBLIC "/DUNICODE")
     target_compile_options(mango PUBLIC "/utf-8")
     target_compile_options(mango PUBLIC "/MP")

--- a/include/mango/core/bits.hpp
+++ b/include/mango/core/bits.hpp
@@ -280,6 +280,12 @@ namespace mango
 
 #endif
 
+    static inline
+    u8 u8_clamp(s32 value)
+    {
+        return u8(byteclamp(value));
+    }
+
     static constexpr
     int mul8bit(int a, int b)
     {

--- a/include/mango/core/bits.hpp
+++ b/include/mango/core/bits.hpp
@@ -214,31 +214,31 @@ namespace mango
     static constexpr
     u8 u8_mask(u8 c0, u8 c1, u8 c2, u8 c3) noexcept
     {
-        return (c3 << 6) | (c2 << 4) | (c1 << 2) | c0;
+        return u8((c3 << 6) | (c2 << 4) | (c1 << 2) | c0);
     }
 
     static constexpr
     u16 u16_mask(char c0, char c1) noexcept
     {
-        return (c1 << 8) | c0;
+        return u16((c1 << 8) | c0);
     }
 
     static constexpr
     u16 u16_mask_rev(char c0, char c1) noexcept
     {
-        return (c0 << 8) | c1;
+        return u16((c0 << 8) | c1);
     }
 
     static constexpr
     u32 u32_mask(char c0, char c1, char c2, char c3) noexcept
     {
-        return (c3 << 24) | (c2 << 16) | (c1 << 8) | c0;
+        return u32((c3 << 24) | (c2 << 16) | (c1 << 8) | c0);
     }
 
     static constexpr
     u32 u32_mask_rev(char c0, char c1, char c2, char c3) noexcept
     {
-        return (c0 << 24) | (c1 << 16) | (c2 << 8) | c3;
+        return u32((c0 << 24) | (c1 << 16) | (c2 << 8) | c3);
     }
 
     // ----------------------------------------------------------------------------
@@ -259,7 +259,7 @@ namespace mango
     static inline
     u32 byteclamp(s32 value)
     {
-        return std::max(0, std::min(255, value));
+        return u32(std::max(0, std::min(255, value)));
     }
 
 #elif defined(MANGO_COMPILER_GCC)
@@ -267,7 +267,7 @@ namespace mango
     static inline
     u32 byteclamp(s32 value)
     {
-        return std::clamp(value, 0, 255);
+        return u32(std::clamp(value, 0, 255));
     }
 
 #else
@@ -397,7 +397,7 @@ namespace mango
     u16 u16_scale(u16 value, int from, int to)
     {
         // scale value "from" bits "to" bits
-        return value * ((1 << to) - 1) / ((1 << from) - 1);
+        return u16(value * ((1 << to) - 1) / ((1 << from) - 1));
     }
 
     static constexpr
@@ -418,7 +418,7 @@ namespace mango
     u16 u16_extend(u16 value, int from, int to)
     {
         // bit-pattern replicating scaling (can at most double the bits)
-        return (value << (to - from)) | (value >> (from * 2 - to));
+        return u16((value << (to - from)) | (value >> (from * 2 - to)));
     }
 
     static constexpr
@@ -439,7 +439,7 @@ namespace mango
     s16 s16_extend(s16 value, int bits)
     {
         // sign-extend to 16 bits
-        u16 mask = 1 << (bits - 1);
+        u16 mask = u16(1 << (bits - 1));
         return (value ^ mask) - mask;
     }
 
@@ -448,7 +448,7 @@ namespace mango
     {
         // sign-extend to 32 bits
         u32 mask = 1u << (bits - 1);
-        return (value ^ mask) - mask;
+        return s32((value ^ mask) - mask);
     }
 
     static constexpr
@@ -456,7 +456,7 @@ namespace mango
     {
         // sign-extend to 64 bits
         u64 mask = 1ull << (bits - 1);
-        return (value ^ mask) - mask;
+        return s64((value ^ mask) - mask);
     }
 
     // ----------------------------------------------------------------------------
@@ -466,9 +466,9 @@ namespace mango
     static inline
     u8 u8_reverse_bits(u8 value)
     {
-        value = ((value >> 1) & 0x55) | ((value << 1) & 0xaa);
-        value = ((value >> 2) & 0x33) | ((value << 2) & 0xcc);
-        value = (value >> 4) | (value << 4);
+        value = u8(((value >> 1) & 0x55) | ((value << 1) & 0xaa));
+        value = u8(((value >> 2) & 0x33) | ((value << 2) & 0xcc));
+        value = u8((value >> 4) | (value << 4));
         return value;
     }
 
@@ -480,16 +480,16 @@ namespace mango
     u16 u16_select(u16 mask, u16 a, u16 b)
     {
         // bitwise mask ? a : b
-        return (mask & (a ^ b)) ^ b;
+        return u16((mask & (a ^ b)) ^ b);
     }
 
     static inline
     u16 u16_reverse_bits(u16 value)
     {
-        value = ((value >> 1) & 0x5555) | ((value << 1) & 0xaaaa);
-        value = ((value >> 2) & 0x3333) | ((value << 2) & 0xcccc);
-        value = ((value >> 4) & 0x0f0f) | ((value << 4) & 0xf0f0);
-        value = (value >> 8) | (value << 8);
+        value = u16(((value >> 1) & 0x5555) | ((value << 1) & 0xaaaa));
+        value = u16(((value >> 2) & 0x3333) | ((value << 2) & 0xcccc));
+        value = u16(((value >> 4) & 0x0f0f) | ((value << 4) & 0xf0f0));
+        value = u16((value >> 8) | (value << 8));
         return value;
     }
 
@@ -624,7 +624,7 @@ namespace mango
     static inline
     int u32_tzcnt(u32 value)
     {
-        return _tzcnt_u32(value);
+        return int(_tzcnt_u32(value));
     }
 
 #elif defined(__aarch64__) && !defined(MANGO_COMPILER_GCC)
@@ -891,7 +891,7 @@ namespace mango
 #if defined(__BMI__)
 
     static inline
-    u32 u32_extract_bits(u32 value, int offset, int size)
+    u32 u32_extract_bits(u32 value, u32 offset, u32 size)
     {
         return _bextr_u32(value, offset, size);
     }
@@ -899,7 +899,7 @@ namespace mango
 #else
 
     static constexpr
-    u32 u32_extract_bits(u32 value, int offset, int size)
+    u32 u32_extract_bits(u32 value, u32 offset, u32 size)
     {
         return (value >> offset) & ((1 << size) - 1);
     }
@@ -912,7 +912,7 @@ namespace mango
         value ^= value >> 16;
         value ^= value >> 8;
         value ^= value >> 4;
-        return (0b0110100110010110 >> (value & 0xf)) & 1;
+        return u32((0b0110100110010110 >> (value & 0xf)) & 1);
     }
 
     // ----------------------------------------------------------------------------
@@ -1443,7 +1443,7 @@ namespace mango
 #if defined(__BMI__) && defined(MANGO_CPU_64BIT)
 
     static inline
-    u64 u64_extract_bits(u64 value, int offset, int size)
+    u64 u64_extract_bits(u64 value, u32 offset, u32 size)
     {
         return _bextr_u64(value, offset, size);
     }
@@ -1465,7 +1465,7 @@ namespace mango
         value ^= value >> 16;
         value ^= value >> 8;
         value ^= value >> 4;
-        return (0b0110100110010110 >> (value & 0xf)) & 1;
+        return u64((0b0110100110010110 >> (value & 0xf)) & 1);
     }
 
     // ----------------------------------------------------------------------------

--- a/include/mango/core/bits.hpp
+++ b/include/mango/core/bits.hpp
@@ -421,6 +421,13 @@ namespace mango
     }
 
     static constexpr
+    u8 u8_extend(u32 value, int from, int to)
+    {
+        // bit-pattern replicating scaling (can at most double the bits)
+        return u8((value << (to - from)) | (value >> (from * 2 - to)));
+    }
+
+    static constexpr
     u16 u16_extend(u16 value, int from, int to)
     {
         // bit-pattern replicating scaling (can at most double the bits)

--- a/include/mango/core/buffer.hpp
+++ b/include/mango/core/buffer.hpp
@@ -59,17 +59,17 @@ namespace mango
         u8* allocate(size_t bytes) const;
     };
 
-    class BufferStream : public Stream
+    class MemoryStream : public Stream
     {
     private:
         Buffer m_buffer;
         u64 m_offset;
 
     public:
-        BufferStream();
-        BufferStream(const u8* source, u64 bytes);
-        BufferStream(ConstMemory memory);
-        ~BufferStream();
+        MemoryStream();
+        MemoryStream(const u8* source, u64 bytes);
+        MemoryStream(ConstMemory memory);
+        ~MemoryStream();
 
         operator ConstMemory () const;
         operator Memory () const;
@@ -82,12 +82,24 @@ namespace mango
         void read(void* dest, u64 bytes) override;
         void write(const void* source, u64 bytes) override;
 
-        void write(ConstMemory memory)
-        {
-            Stream::write(memory);
-        }
+        void write(ConstMemory memory);
     };
 
-    using MemoryStream = BufferStream;
+    class ConstMemoryStream : public Stream
+    {
+    protected:
+        ConstMemory m_memory;
+        u64 m_offset;
+
+    public:
+        ConstMemoryStream(ConstMemory memory);
+        ~ConstMemoryStream();
+
+        u64 size() const override;
+        u64 offset() const override;
+        void seek(s64 distance, SeekMode mode) override;
+        void read(void* dest, u64 bytes) override;
+        void write(const void* data, u64 size) override;
+    };
 
 } // namespace mango

--- a/include/mango/core/configure.hpp
+++ b/include/mango/core/configure.hpp
@@ -390,10 +390,7 @@
         #ifndef __SSE2__
         #define __SSE2__
         #endif
-    #endif
-
-    // SSE2 enabled with /arch:SSE2 is visible like this
-    #if _M_IX86_FP == 2
+    #elif _M_IX86_FP == 2
         #ifndef __SSE2__
         #define __SSE2__
         #endif
@@ -460,7 +457,8 @@
 
     #endif
 
-    #pragma warning(disable : 4146 4996 4201 4244 26812 26495)
+    #pragma warning(disable : 4146 4996 4201 4244 4623 4710 4711 4820 26812 26495)
+    #pragma warning(disable : 4625 4626 4627 5026 5027 4464 4324 5039 5045 4582 4365 4800)
 
 #elif defined(__llvm__) || defined(__clang__)
 

--- a/include/mango/core/configure.hpp
+++ b/include/mango/core/configure.hpp
@@ -12,6 +12,19 @@
 #include <new>
 
 // -----------------------------------------------------------------------
+// warnings
+// -----------------------------------------------------------------------
+
+#if defined(_MSC_VER) || defined(_WIN32) || defined(_WINDOWS_) || defined(__MINGW32__) || defined(__MINGW64__)
+
+    // These warnings must be disabled BEFORE including any windows headers
+    #pragma warning(disable : 4146 4996 4201 4244 4623 4710 4711 4820 26812 26495)
+    #pragma warning(disable : 4625 4626 4627 5026 5027 4464 4324 5039 5045 4582 4365 4800 4061 5219 5246 4668 5267)
+    #pragma warning(disable : 4191 5039)
+
+#endif
+
+// -----------------------------------------------------------------------
 // platform
 // -----------------------------------------------------------------------
 
@@ -456,9 +469,6 @@
         #endif
 
     #endif
-
-    #pragma warning(disable : 4146 4996 4201 4244 4623 4710 4711 4820 26812 26495)
-    #pragma warning(disable : 4625 4626 4627 5026 5027 4464 4324 5039 5045 4582 4365 4800)
 
 #elif defined(__llvm__) || defined(__clang__)
 

--- a/include/mango/core/half.hpp
+++ b/include/mango/core/half.hpp
@@ -304,13 +304,13 @@ namespace mango
         Half& operator = (float s)
         {
             __m128i temp = _mm_cvtps_ph(_mm_set1_ps(s), _MM_FROUND_TO_NEAREST_INT);
-            u = _mm_extract_epi64(temp, 0) & 0xffff;
+            u = u16(_mm_extract_epi64(temp, 0) & 0xffff);
             return *this;
         }
 
         operator float () const
         {
-            __m128 temp = _mm_cvtph_ps(_mm_set1_epi64x(u64(u)));
+            __m128 temp = _mm_cvtph_ps(_mm_set1_epi64x(s64(u)));
             return _mm_cvtss_f32(temp);
         }
 
@@ -368,7 +368,7 @@ namespace mango
 
         operator u32 () const
         {
-            u32 v = (data[2] << 16) | (data[1] << 8) | data[0];
+            u32 v = u32((data[2] << 16) | (data[1] << 8) | data[0]);
             return v;
         }
 

--- a/include/mango/core/pointer.hpp
+++ b/include/mango/core/pointer.hpp
@@ -204,26 +204,30 @@ namespace mango::detail
             p += memory.size;
         }
 
-        void write8(u8 value)
+        template <typename T>
+        void write8(T value)
         {
-            *p++ = value;
+            *p++ = u8(value);
         }
 
-        void write16(u16 value)
+        template <typename T>
+        void write16(T value)
         {
-            ustore16(p, value);
+            ustore16(p, u16(value));
             p += 2;
         }
 
-        void write32(u32 value)
+        template <typename T>
+        void write32(T value)
         {
-            ustore32(p, value);
+            ustore32(p, u32(value));
             p += 4;
         }
 
-        void write64(u64 value)
+        template <typename T>
+        void write64(T value)
         {
-            ustore64(p, value);
+            ustore64(p, u64(value));
             p += 8;
         }
 
@@ -366,50 +370,48 @@ namespace mango::detail
             p += memory.size;
         }
 
-        void write8(u8 value)
+        template <typename T>
+        void write8(T value)
         {
-            *p++ = value;
+            *p++ = u8(value);
         }
 
-        void write16(u16 value)
+        template <typename T>
+        void write16(T value)
         {
-            value = byteswap(value);
-            ustore16(p, value);
+            ustore16(p, byteswap(u16(value)));
             p += 2;
         }
 
-        void write32(u32 value)
+        template <typename T>
+        void write32(T value)
         {
-            value = byteswap(value);
-            ustore32(p, value);
+            ustore32(p, byteswap(u32(value)));
             p += 4;
         }
 
-        void write64(u64 value)
+        template <typename T>
+        void write64(T value)
         {
-            value = byteswap(value);
-            ustore64(p, value);
+            ustore64(p, byteswap(u64(value)));
             p += 8;
         }
 
         void write16f(float16 value)
         {
-            value = byteswap(value);
-            ustore16f(p, value);
+            ustore16f(p, byteswap(value));
             p += 2;
         }
 
         void write32f(float32 value)
         {
-            value = byteswap(value);
-            ustore32f(p, value);
+            ustore32f(p, byteswap(value));
             p += 4;
         }
 
         void write64f(float64 value)
         {
-            value = byteswap(value);
-            ustore64f(p, value);
+            ustore64f(p, byteswap(value));
             p += 8;
         }
     };

--- a/include/mango/core/stream.hpp
+++ b/include/mango/core/stream.hpp
@@ -45,27 +45,6 @@ namespace mango
     };
 
     // --------------------------------------------------------------
-    // ConstMemoryStream
-    // --------------------------------------------------------------
-
-    class ConstMemoryStream : public Stream
-    {
-    protected:
-        ConstMemory m_memory;
-        u64 m_offset;
-
-    public:
-        ConstMemoryStream(ConstMemory memory);
-        ~ConstMemoryStream();
-
-        u64 size() const;
-        u64 offset() const;
-        void seek(s64 distance, SeekMode mode);;
-        void read(void* dest, u64 bytes);
-        void write(const void* data, u64 size);
-    };
-
-    // --------------------------------------------------------------
     // SameEndianStream
     // --------------------------------------------------------------
 

--- a/include/mango/core/stream.hpp
+++ b/include/mango/core/stream.hpp
@@ -168,25 +168,32 @@ namespace mango
             s.write(memory);
         }
 
-        void write8(u8 value)
+        template <typename T>
+        void write8(T value)
         {
-            s.write(&value, sizeof(u8));
-
+            u8 temp = u8(value);
+            s.write(&temp, sizeof(temp));
         }
 
-        void write16(u16 value)
+        template <typename T>
+        void write16(T value)
         {
-            s.write(&value, sizeof(u16));
+            u16 temp = u16(value);
+            s.write(&temp, sizeof(temp));
         }
 
-        void write32(u32 value)
+        template <typename T>
+        void write32(T value)
         {
-            s.write(&value, sizeof(u32));
+            u32 temp = u32(value);
+            s.write(&temp, sizeof(temp));
         }
 
-        void write64(u64 value)
+        template <typename T>
+        void write64(T value)
         {
-            s.write(&value, sizeof(u64));
+            u64 temp = u64(value);
+            s.write(&temp, sizeof(temp));
         }
 
         void write16f(Half value)
@@ -311,27 +318,35 @@ namespace mango
             s.write(memory);
         }
 
-        void write8(u8 value)
+        template <typename T>
+        void write8(T value)
         {
-            s.write(&value, 1);
+            u8 temp = u8(value);
+            s.write(&temp, sizeof(temp));
         }
 
-        void write16(u16 value)
+        template <typename T>
+        void write16(T value)
         {
-            value = byteswap(value);
-            s.write(&value, 2);
+            u16 temp = u16(value);
+            temp = byteswap(temp);
+            s.write(&temp, sizeof(temp));
         }
 
-        void write32(u32 value)
+        template <typename T>
+        void write32(T value)
         {
-            value = byteswap(value);
-            s.write(&value, 4);
+            u32 temp = u32(value);
+            temp = byteswap(temp);
+            s.write(&temp, sizeof(temp));
         }
 
-        void write64(u64 value)
+        template <typename T>
+        void write64(T value)
         {
-            value = byteswap(value);
-            s.write(&value, 8);
+            u64 temp = u64(value);
+            temp = byteswap(temp);
+            s.write(&temp, sizeof(temp));
         }
 
         void write16f(Half value)

--- a/include/mango/core/string.hpp
+++ b/include/mango/core/string.hpp
@@ -11,7 +11,8 @@
 #include <mango/core/configure.hpp>
 
 #ifdef _MSC_VER
-#define FMT_UNICODE 0
+    #define FMT_UNICODE 0
+    #pragma warning(disable : 5045)
 #endif
 #include <mango/fmt/format.h>
 #include <mango/fmt/color.h>

--- a/include/mango/core/string.hpp
+++ b/include/mango/core/string.hpp
@@ -43,6 +43,7 @@ namespace mango
     std::vector<std::string> split(const std::string& s, const std::string& delimiter);
     std::vector<std::string_view> split(std::string_view s, std::string_view delimiter);
     const u8* memchr(const u8* p, u8 value, size_t count);
+    size_t stringLength(const char* s, size_t maxlen);
     float parseFloat(std::string_view str);
     int parseInt(std::string_view str);
 

--- a/include/mango/core/timer.hpp
+++ b/include/mango/core/timer.hpp
@@ -31,19 +31,19 @@ namespace mango
         u64 ms() const
         {
             // time age in milliseconds
-            return std::chrono::duration_cast<std::chrono::milliseconds>(now() - m_start).count();
+            return u64(std::chrono::duration_cast<std::chrono::milliseconds>(now() - m_start).count());
         }
 
         u64 us() const
         {
             // timer age in microseconds
-            return std::chrono::duration_cast<std::chrono::microseconds>(now() - m_start).count();
+            return u64(std::chrono::duration_cast<std::chrono::microseconds>(now() - m_start).count());
         }
 
         u64 ns() const
         {
             // timer age in nanoseconds
-            return std::chrono::duration_cast<std::chrono::nanoseconds>(now() - m_start).count();
+            return u64(std::chrono::duration_cast<std::chrono::nanoseconds>(now() - m_start).count());
         }
 
         Time now() const
@@ -72,13 +72,13 @@ namespace mango
 
     struct LocalTime
     {
-        u16  year;   // [....]
-        u16  month;  // [1, 12]
-        u16  day;    // [1, 31]
-        u16  wday;   // [0, 6]
-        u16  hour;   // [0, 23]
-        u16  minute; // [0, 59]
-        u16  second; // [0, 60]
+        int  year;   // [....]
+        int  month;  // [1, 12]
+        int  day;    // [1, 31]
+        int  wday;   // [0, 6]
+        int  hour;   // [0, 23]
+        int  minute; // [0, 59]
+        int  second; // [0, 60]
     };
 
     LocalTime getLocalTime();

--- a/include/mango/filesystem/mapper.hpp
+++ b/include/mango/filesystem/mapper.hpp
@@ -59,12 +59,12 @@ namespace mango::filesystem
             files.clear();
         }
 
-        FileInfo& operator [] (int index)
+        FileInfo& operator [] (size_t index)
         {
             return files[index];
         }
 
-        const FileInfo& operator [] (int index) const
+        const FileInfo& operator [] (size_t index) const
         {
             return files[index];
         }

--- a/include/mango/filesystem/path.hpp
+++ b/include/mango/filesystem/path.hpp
@@ -73,7 +73,7 @@ namespace mango::filesystem
             return m_index.empty();
         }
 
-        const FileInfo& operator [] (int index) const
+        const FileInfo& operator [] (size_t index) const
         {
             updateIndex();
             return m_index[index];

--- a/include/mango/image/color.hpp
+++ b/include/mango/image/color.hpp
@@ -42,7 +42,7 @@ namespace mango::image
             littleEndian::ustore32(this, 0);
         }
 
-        Color(u8 red, u8 green, u8 blue, u8 alpha)
+        Color(u32 red, u32 green, u32 blue, u32 alpha)
         {
             littleEndian::ustore32(this, makeRGBA(red, green, blue, alpha));
         }

--- a/include/mango/image/format.hpp
+++ b/include/mango/image/format.hpp
@@ -164,7 +164,7 @@ namespace mango::image
     struct LuminanceFormat : Format
     {
         explicit LuminanceFormat(int bits, u32 luminanceMask, u32 alphaMask, u16 flags = 0);
-        explicit LuminanceFormat(int bits, Type type, u8 luminanceBits, u8 alphaBits, u16 flags = 0);
+        explicit LuminanceFormat(int bits, Type type, u32 luminanceBits, u32 alphaBits, u16 flags = 0);
     };
 
     struct IndexedFormat : Format

--- a/include/mango/math/vector_simd.hpp
+++ b/include/mango/math/vector_simd.hpp
@@ -57,6 +57,8 @@ namespace mango::math
     {
         VectorType m;
 
+        ScalarAccessor(const ScalarAccessor& accessor) = default;
+
         operator ScalarType () const
         {
             return simd::get_component<Index>(m);

--- a/license
+++ b/license
@@ -1,5 +1,5 @@
 MANGO
-Copyright (c) 2012-2024 Twilight Finland 3D Oy Ltd. All rights reserved.
+Copyright (c) 2012-2025 Twilight Finland 3D Oy Ltd. All rights reserved.
 
 This software is provided 'as-is', without any express or implied
 warranty. In no event will the authors be held liable for any damages

--- a/source/external/bc/BC.h
+++ b/source/external/bc/BC.h
@@ -15,7 +15,7 @@
 #include <algorithm>
 #include <float.h>
 #include <stdint.h>
-#include "../../../include/mango/mango.hpp"
+#include <mango/mango.hpp>
 
 namespace DirectX
 {

--- a/source/external/bc/BC6HBC7.cpp
+++ b/source/external/bc/BC6HBC7.cpp
@@ -2637,12 +2637,12 @@ void D3DX_BC7::Decode(u8* output, size_t stride) const noexcept
         {
             for (size_t i = 0; i < uNumEndPts; i++)
             {
-                size_t pi = i * ms_aInfo[uMode].uPBits / uNumEndPts;
+                size_t xpi = i * ms_aInfo[uMode].uPBits / uNumEndPts;
                 for (uint8_t ch = 0; ch < BC7_NUM_CHANNELS; ch++)
                 {
                     if (RGBAPrec[ch] != RGBAPrecWithP[ch])
                     {
-                        c[i][ch] = static_cast<uint8_t>((unsigned(c[i][ch]) << 1) | P[pi]);
+                        c[i][ch] = static_cast<uint8_t>((unsigned(c[i][ch]) << 1) | P[xpi]);
                     }
                 }
             }

--- a/source/external/fastgltf/include/fastgltf/base64.hpp
+++ b/source/external/fastgltf/include/fastgltf/base64.hpp
@@ -38,6 +38,7 @@
 #ifdef _MSC_VER
 #pragma warning(push) // attribute 'x' is not recognized
 #pragma warning(disable : 5030)
+#pragma warning(disable : 5045) // mango customization
 #endif
 
 namespace fastgltf::base64 {

--- a/source/external/fastgltf/include/fastgltf/core.hpp
+++ b/source/external/fastgltf/include/fastgltf/core.hpp
@@ -38,6 +38,7 @@
 #pragma warning(push)
 #pragma warning(disable : 5030) // attribute 'x' is not recognized
 #pragma warning(disable : 4514) // unreferenced inline function has been removed
+#pragma warning(disable : 4668 5267 4365 5246 4800 5045) // mango customization
 #endif
 
 // fwd

--- a/source/external/fastgltf/include/fastgltf/math.hpp
+++ b/source/external/fastgltf/include/fastgltf/math.hpp
@@ -33,6 +33,10 @@
 #include <tuple>
 #endif
 
+#ifdef _MSC_VER
+#pragma warning(disable : 5246) // mango customization
+#endif
+
 #include <fastgltf/util.hpp>
 
 /**

--- a/source/external/fastgltf/include/fastgltf/types.hpp
+++ b/source/external/fastgltf/include/fastgltf/types.hpp
@@ -38,6 +38,13 @@
 #include <vector>
 #endif
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 5030) // attribute 'x' is not recognized
+#pragma warning(disable : 4514) // unreferenced inline function has been removed
+#pragma warning(disable : 4668 4582 5267 5263) // mango customization
+#endif
+
 // Utils header already includes some headers, which we'll try and avoid including twice.
 #include <fastgltf/util.hpp>
 #include <fastgltf/math.hpp>
@@ -87,13 +94,6 @@
 #if !defined(FASTGLTF_USE_STD_MODULE) || !FASTGLTF_USE_STD_MODULE
 #include <span>
 #endif
-#endif
-
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5030) // attribute 'x' is not recognized
-#pragma warning(disable : 4514) // unreferenced inline function has been removed
-#pragma warning(disable : 5267) // mango customization
 #endif
 
 #define FASTGLTF_QUOTE_Q(x) #x

--- a/source/external/fastgltf/include/fastgltf/types.hpp
+++ b/source/external/fastgltf/include/fastgltf/types.hpp
@@ -93,6 +93,7 @@
 #pragma warning(push)
 #pragma warning(disable : 5030) // attribute 'x' is not recognized
 #pragma warning(disable : 4514) // unreferenced inline function has been removed
+#pragma warning(disable : 5267) // mango customization
 #endif
 
 #define FASTGLTF_QUOTE_Q(x) #x

--- a/source/external/fastgltf/include/fastgltf/util.hpp
+++ b/source/external/fastgltf/include/fastgltf/util.hpp
@@ -38,6 +38,11 @@
 #include <type_traits>
 #endif
 
+// mango customization
+#ifdef _MSC_VER
+#pragma warning(disable : 5027 4626 4623)
+#endif
+
 #ifndef FASTGLTF_EXPORT
 #define FASTGLTF_EXPORT
 #endif

--- a/source/external/fastgltf/include/fastgltf/util.hpp
+++ b/source/external/fastgltf/include/fastgltf/util.hpp
@@ -132,6 +132,7 @@
 #pragma warning(push)
 #pragma warning(disable : 5030) // attribute 'x' is not recognized
 #pragma warning(disable : 4514) // unreferenced inline function has been removed
+#pragma warning(disable : 5045 5246) // mango customization
 #endif
 
 namespace fastgltf {

--- a/source/external/fastgltf/src/base64.cpp
+++ b/source/external/fastgltf/src/base64.cpp
@@ -28,6 +28,13 @@
 #error "fastgltf requires C++17"
 #endif
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 5030) // attribute 'x' is not recognized
+#pragma warning(disable : 4710) // function not inlined
+#pragma warning(disable : 5045 5246 4514 4365 4800 5263 4820 4625 4626 4668 4623 4061 4100 5027 5026) // mango customization
+#endif
+
 #include <array>
 #include <cmath>
 #include <functional>
@@ -51,12 +58,6 @@
 #endif
 #elif defined(FASTGLTF_IS_A64)
 #include <arm_neon.h> // Includes arm64_neon.h on MSVC
-#endif
-
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5030) // attribute 'x' is not recognized
-#pragma warning(disable : 4710) // function not inlined
 #endif
 
 namespace fg = fastgltf;

--- a/source/external/fastgltf/src/fastgltf.cpp
+++ b/source/external/fastgltf/src/fastgltf.cpp
@@ -38,7 +38,7 @@
 #pragma warning(disable : 5030) // attribute 'x' is not recognized
 #pragma warning(disable : 4514) // unreferenced inline function has been removed
 #pragma warning(disable : 4710) // function not inlined
-#pragma warning(disable : 5045 4365) // mango customization
+#pragma warning(disable : 4100 4623 4626 4946 4668 4820 4826 4625 4061 5045 4365 4800 5026 5027) // mango customization
 #endif
 
 #include <simdjson.h>

--- a/source/external/fastgltf/src/fastgltf.cpp
+++ b/source/external/fastgltf/src/fastgltf.cpp
@@ -38,6 +38,7 @@
 #pragma warning(disable : 5030) // attribute 'x' is not recognized
 #pragma warning(disable : 4514) // unreferenced inline function has been removed
 #pragma warning(disable : 4710) // function not inlined
+#pragma warning(disable : 5045 4365) // mango customization
 #endif
 
 #include <simdjson.h>

--- a/source/external/fastgltf/src/io.cpp
+++ b/source/external/fastgltf/src/io.cpp
@@ -24,6 +24,11 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+// mango customization
+#ifdef _MSC_VER
+#pragma warning(disable : 4061 4365 4668 4800 4100 5026 5027 5263 5039 4626 4820 4625 4623)
+#endif
+
 #include <simdjson.h>
 
 #include <fastgltf/core.hpp>

--- a/source/external/google/etc.cpp
+++ b/source/external/google/etc.cpp
@@ -24,11 +24,11 @@
     The original source code has been modified for integration.
 */
 
-#include "../../../include/mango/core/configure.hpp"
-#include "../../../include/mango/core/bits.hpp"
-#include "../../../include/mango/core/endian.hpp"
-#include "../../../include/mango/math/vector.hpp"
-#include "../../../include/mango/image/compression.hpp"
+#include <mango/core/configure.hpp>
+#include <mango/core/bits.hpp>
+#include <mango/core/endian.hpp>
+#include <mango/math/vector.hpp>
+#include <mango/image/compression.hpp>
 
 #define ETC_ENABLE_SIMD
 

--- a/source/external/google/etc.cpp
+++ b/source/external/google/etc.cpp
@@ -42,7 +42,7 @@ namespace
         return u32(u64_extract_bits(src, offset, count));
     }
 
-    inline u8 extend5Delta3To8 (int base5, int delta3)
+    inline u32 extend5Delta3To8 (int base5, int delta3)
     {
         const int t = base5 + s32_extend(delta3, 3);
         return u32_extend(t, 5, 8);
@@ -206,9 +206,9 @@ namespace
             const int flipBit  = getBits(src, 32, 1);
             const u32 table[2] = { getBits(src, 37, 3), getBits(src, 34, 3) };
 
-            u8 baseR[2];
-            u8 baseG[2];
-            u8 baseB[2];
+            u32 baseR[2];
+            u32 baseG[2];
+            u32 baseB[2];
 
             if (mode == MODE_INDIVIDUAL)
             {
@@ -317,20 +317,20 @@ namespace
             // T and H modes have some steps in common, handle them here.
             static const int distTable[8] = { 3, 6, 11, 16, 23, 32, 41, 64 };
 
-            u8 paintR[4];
-            u8 paintG[4];
-            u8 paintB[4];
+            u32 paintR[4];
+            u32 paintG[4];
+            u32 paintB[4];
 
             if (mode == MODE_T)
             {
                 // T mode, calculate paint values.
-                const u8  R1a     = getBits(src, 59, 2);
-                const u8  R1b     = getBits(src, 56, 2);
-                const u8  G1      = getBits(src, 52, 4);
-                const u8  B1      = getBits(src, 48, 4);
-                const u8  R2      = getBits(src, 44, 4);
-                const u8  G2      = getBits(src, 40, 4);
-                const u8  B2      = getBits(src, 36, 4);
+                const u32  R1a     = getBits(src, 59, 2);
+                const u32  R1b     = getBits(src, 56, 2);
+                const u32  G1      = getBits(src, 52, 4);
+                const u32  B1      = getBits(src, 48, 4);
+                const u32  R2      = getBits(src, 44, 4);
+                const u32  G2      = getBits(src, 40, 4);
+                const u32  B2      = getBits(src, 36, 4);
                 const u32 distNdx = (getBits(src, 34, 2) << 1) | getBits(src, 32, 1);
                 const int dist    = distTable[distNdx];
 
@@ -340,24 +340,24 @@ namespace
                 paintR[2] = u32_extend(R2, 4, 8);
                 paintG[2] = u32_extend(G2, 4, 8);
                 paintB[2] = u32_extend(B2, 4, 8);
-                paintR[1] = byteclamp(paintR[2] + dist);
-                paintG[1] = byteclamp(paintG[2] + dist);
-                paintB[1] = byteclamp(paintB[2] + dist);
-                paintR[3] = byteclamp(paintR[2] - dist);
-                paintG[3] = byteclamp(paintG[2] - dist);
-                paintB[3] = byteclamp(paintB[2] - dist);
+                paintR[1] = u8_clamp(paintR[2] + dist);
+                paintG[1] = u8_clamp(paintG[2] + dist);
+                paintB[1] = u8_clamp(paintB[2] + dist);
+                paintR[3] = u8_clamp(paintR[2] - dist);
+                paintG[3] = u8_clamp(paintG[2] - dist);
+                paintB[3] = u8_clamp(paintB[2] - dist);
             }
             else
             {
                 // H mode, calculate paint values.
-                const u8 R1	  = getBits(src, 59, 4);
-                const u8 G1a  = getBits(src, 56, 3);
-                const u8 G1b  = getBits(src, 52, 1);
-                const u8 B1a  = getBits(src, 51, 1);
-                const u8 B1b  = getBits(src, 47, 3);
-                const u8 R2	  = getBits(src, 43, 4);
-                const u8 G2	  = getBits(src, 39, 4);
-                const u8 B2	  = getBits(src, 35, 4);
+                const u32 R1   = getBits(src, 59, 4);
+                const u32 G1a  = getBits(src, 56, 3);
+                const u32 G1b  = getBits(src, 52, 1);
+                const u32 B1a  = getBits(src, 51, 1);
+                const u32 B1b  = getBits(src, 47, 3);
+                const u32 R2   = getBits(src, 43, 4);
+                const u32 G2   = getBits(src, 39, 4);
+                const u32 B2   = getBits(src, 35, 4);
 
                 int baseR[2];
                 int	baseG[2];
@@ -377,18 +377,18 @@ namespace
                 distNdx       = (getBits(src, 34, 1) << 2) | (getBits(src, 32, 1) << 1) | (baseValue[0] >= baseValue[1]);
                 dist          = distTable[distNdx];
 
-                paintR[0] = byteclamp(baseR[0] + dist);
-                paintG[0] = byteclamp(baseG[0] + dist);
-                paintB[0] = byteclamp(baseB[0] + dist);
-                paintR[1] = byteclamp(baseR[0] - dist);
-                paintG[1] = byteclamp(baseG[0] - dist);
-                paintB[1] = byteclamp(baseB[0] - dist);
-                paintR[2] = byteclamp(baseR[1] + dist);
-                paintG[2] = byteclamp(baseG[1] + dist);
-                paintB[2] = byteclamp(baseB[1] + dist);
-                paintR[3] = byteclamp(baseR[1] - dist);
-                paintG[3] = byteclamp(baseG[1] - dist);
-                paintB[3] = byteclamp(baseB[1] - dist);
+                paintR[0] = u8_clamp(baseR[0] + dist);
+                paintG[0] = u8_clamp(baseG[0] + dist);
+                paintB[0] = u8_clamp(baseB[0] + dist);
+                paintR[1] = u8_clamp(baseR[0] - dist);
+                paintG[1] = u8_clamp(baseG[0] - dist);
+                paintB[1] = u8_clamp(baseB[0] - dist);
+                paintR[2] = u8_clamp(baseR[1] + dist);
+                paintG[2] = u8_clamp(baseG[1] + dist);
+                paintB[2] = u8_clamp(baseB[1] + dist);
+                paintR[3] = u8_clamp(baseR[1] - dist);
+                paintG[3] = u8_clamp(baseG[1] - dist);
+                paintB[3] = u8_clamp(baseB[1] - dist);
             }
 
             const u32 paint[] =
@@ -424,13 +424,13 @@ namespace
         else
         {
             // Planar mode.
-            const u8 GO1 = getBits(src, 56, 1);
-            const u8 GO2 = getBits(src, 49, 6);
-            const u8 BO1 = getBits(src, 48, 1);
-            const u8 BO2 = getBits(src, 43, 2);
-            const u8 BO3 = getBits(src, 39, 3);
-            const u8 RH1 = getBits(src, 34, 5);
-            const u8 RH2 = getBits(src, 32, 1);
+            const u32 GO1 = getBits(src, 56, 1);
+            const u32 GO2 = getBits(src, 49, 6);
+            const u32 BO1 = getBits(src, 48, 1);
+            const u32 BO2 = getBits(src, 43, 2);
+            const u32 BO3 = getBits(src, 39, 3);
+            const u32 RH1 = getBits(src, 34, 5);
+            const u32 RH2 = getBits(src, 32, 1);
 
             const int RO = u32_extend(getBits(src, 57, 6), 6, 8);
             const int GO = u32_extend((GO1 << 6) | GO2, 7, 8);
@@ -531,7 +531,7 @@ namespace
                 const u32 modifierNdx = getBits(src, pixelBitNdx, 3);
                 const int modifier    = modifierTable[tableNdx][modifierNdx];
 
-                dest[3] = byteclamp(baseCodeword + multiplier * modifier);
+                dest[3] = u8_clamp(baseCodeword + multiplier * modifier);
                 dest += 4;
             }
         }

--- a/source/external/google/etc1.cpp
+++ b/source/external/google/etc1.cpp
@@ -16,8 +16,8 @@
 */
 
 #include <string.h>
-#include "../../../include/mango/core/configure.hpp"
-#include "../../../include/mango/image/compression.hpp"
+#include <mango/core/configure.hpp>
+#include <mango/image/compression.hpp>
 
 /* From http://www.khronos.org/registry/gles/extensions/OES/OES_compressed_ETC1_RGB8_texture.txt
 

--- a/source/external/mikktspace/mikktspace.c
+++ b/source/external/mikktspace/mikktspace.c
@@ -30,6 +30,11 @@
 
 #include "mikktspace.h"
 
+// mango customization
+#if defined(_MSC_VER)
+	#pragma warning(disable : 4820 4201 4456 5045)
+#endif
+
 #define TFALSE		0
 #define TTRUE		1
 

--- a/source/external/simdjson/simdjson.cpp
+++ b/source/external/simdjson/simdjson.cpp
@@ -8,6 +8,11 @@
 #ifndef SIMDJSON_SRC_BASE_H
 #define SIMDJSON_SRC_BASE_H
 
+// mango customization
+#ifdef _MSC_VER
+#pragma warning(disable : 4514 5045 4505 5264 4868 4127 4365 4800 4626 4668 5027 4100 4820 4623 4625 5026)
+#endif
+
 /* including simdjson/base.h: #include <simdjson/base.h> */
 /* begin file simdjson/base.h */
 /**

--- a/source/external/unrar/model.hpp
+++ b/source/external/unrar/model.hpp
@@ -62,7 +62,7 @@ struct SEE2_CONTEXT
   uint getMean()
   {
     uint RetVal=GET_SHORT16(Summ) >> Shift;
-    Summ -= RetVal;
+    Summ = ushort(Summ - RetVal);
     return RetVal+(RetVal == 0);
   }
   void update()

--- a/source/mango/core/aes.cpp
+++ b/source/mango/core/aes.cpp
@@ -863,7 +863,7 @@ void aesni_key192_expand(__m128i* schedule, const u8* key)
 {
     // encryption schedule
     __m128i temp1 = _mm_loadu_si128(reinterpret_cast<const __m128i *> (key + 0));
-    __m128i temp2 = _mm_set_epi64x(0, *reinterpret_cast<const u64 *> (key + 16));
+    __m128i temp2 = _mm_set_epi64x(0, *reinterpret_cast<const s64 *> (key + 16));
 
     schedule[0] = temp1;
     schedule[1] = temp2;
@@ -1786,7 +1786,7 @@ void AES::ccm_block_encrypt(Memory output, ConstMemory input, ConstMemory associ
     aes_encrypt_ccm(input.address, aes_u32(input.size),
                     associated.address, u16(associated.size),
                     nonce.address, u16(nonce.size),
-                    output.address, &cipher_length, mac_length,
+                    output.address, &cipher_length, aes_u32(mac_length),
                     m_schedule->schedule, m_bits);
 }
 
@@ -1803,7 +1803,7 @@ void AES::ccm_block_decrypt(Memory output, ConstMemory input, ConstMemory associ
                     associated.address, u16(associated.size),
                     nonce.address, u16(nonce.size),
                     output.address, &plaintext_length,
-                    mac_length, &mac_authorized,
+                    aes_u32(mac_length), &mac_authorized,
                     m_schedule->schedule, m_bits);
 }
 

--- a/source/mango/core/buffer.cpp
+++ b/source/mango/core/buffer.cpp
@@ -359,6 +359,8 @@ namespace mango
 
     void ConstMemoryStream::write(const void* data, u64 size)
     {
+        MANGO_UNREFERENCED(data);
+        MANGO_UNREFERENCED(size);
         MANGO_EXCEPTION("[ConstMemoryStream] Writing into read-only memory.");
     }
 

--- a/source/mango/core/buffer.cpp
+++ b/source/mango/core/buffer.cpp
@@ -191,62 +191,62 @@ namespace mango
     }
 
     // ----------------------------------------------------------------------------
-    // BufferStream
+    // MemoryStream
     // ----------------------------------------------------------------------------
 
-    BufferStream::BufferStream()
+    MemoryStream::MemoryStream()
         : m_buffer()
         , m_offset(0)
     {
     }
 
-    BufferStream::BufferStream(const u8* source, u64 bytes)
+    MemoryStream::MemoryStream(const u8* source, u64 bytes)
         : m_buffer(source, size_t(bytes))
         , m_offset(bytes)
     {
     }
 
-    BufferStream::BufferStream(ConstMemory memory)
+    MemoryStream::MemoryStream(ConstMemory memory)
         : m_buffer(memory)
         , m_offset(memory.size)
     {
     }
 
-    BufferStream::~BufferStream()
+    MemoryStream::~MemoryStream()
     {
     }
 
-    BufferStream::operator ConstMemory () const
-    {
-        return m_buffer;
-    }
-
-    BufferStream::operator Memory () const
+    MemoryStream::operator ConstMemory () const
     {
         return m_buffer;
     }
 
-    BufferStream::operator u8* () const
+    MemoryStream::operator Memory () const
     {
         return m_buffer;
     }
 
-    u8* BufferStream::data() const
+    MemoryStream::operator u8* () const
+    {
+        return m_buffer;
+    }
+
+    u8* MemoryStream::data() const
     {
         return m_buffer.data();
     }
 
-    u64 BufferStream::size() const
+    u64 MemoryStream::size() const
     {
         return u64(m_buffer.size());
     }
 
-    u64 BufferStream::offset() const
+    u64 MemoryStream::offset() const
     {
         return m_offset;
     }
 
-    void BufferStream::seek(s64 distance, SeekMode mode)
+    void MemoryStream::seek(s64 distance, SeekMode mode)
     {
         const u64 size = m_buffer.size();
 
@@ -268,19 +268,19 @@ namespace mango
         m_offset = std::max(u64(0), m_offset);
     }
 
-    void BufferStream::read(void* dest, u64 bytes)
+    void MemoryStream::read(void* dest, u64 bytes)
     {
         const u64 size = m_buffer.size();
         if (m_offset > size || (size - m_offset) < bytes)
         {
-            MANGO_EXCEPTION("[BufferStream] Reading past end of buffer.");
+            MANGO_EXCEPTION("[MemoryStream] Reading past end of buffer.");
         }
 
         std::memcpy(dest, m_buffer.data() + m_offset, size_t(bytes));
         m_offset += bytes;
     }
 
-    void BufferStream::write(const void* source, u64 bytes)
+    void MemoryStream::write(const void* source, u64 bytes)
     {
         const u64 size = m_buffer.size();
         if (m_offset > size)
@@ -298,6 +298,11 @@ namespace mango
             m_buffer.append(src + left, size_t(right));
         }
         m_offset += bytes;
+    }
+
+    void MemoryStream::write(ConstMemory memory)
+    {
+        Stream::write(memory);
     }
 
     // ----------------------------------------------------------------------------

--- a/source/mango/core/compress.cpp
+++ b/source/mango/core/compress.cpp
@@ -957,7 +957,7 @@ namespace ppmd8
             int c = Ppmd8_DecodeSymbol(&ppmd);
             if (c < 0 || offset >= dest.size)
                 break;
-            dest.address[offset++] = c;
+            dest.address[offset++] = u8(c);
         }
 
         CompressionStatus status;

--- a/source/mango/core/cpuinfo.cpp
+++ b/source/mango/core/cpuinfo.cpp
@@ -57,9 +57,9 @@ namespace
 
         // Get CPU information
         cpuid(cpuInfo, 0);
-        unsigned int nIds = cpuInfo[0];
+        int nIds = cpuInfo[0];
 
-        for (unsigned int i = 0; i <= nIds; ++i)
+        for (int i = 0; i <= nIds; ++i)
         {
             cpuid(cpuInfo, i);
 
@@ -108,9 +108,9 @@ namespace
 
         // Get extended CPU information
         cpuid(cpuInfo, 0x80000000);
-        unsigned int nExtIds = cpuInfo[0];
+        int nExtIds = cpuInfo[0];
 
-        for (unsigned int i = 0x80000000; i <= nExtIds; ++i)
+        for (int i = 0x80000000; i <= nExtIds; ++i)
         {
             if (i == 0x80000001)
             {

--- a/source/mango/core/crc32.cpp
+++ b/source/mango/core/crc32.cpp
@@ -1259,7 +1259,7 @@ namespace
     inline
     u32 multmodp(u32 a, u32 b, u32 polynomial)
     {
-        u32 m = 1 << 31;
+        u32 m = u32(1 << 31);
         u32 p = 0;
 
         for ( ;; )
@@ -1283,7 +1283,7 @@ namespace
         const u32 polynomial = table[5];
 
         u32 k = 3;
-        u32 p = 1 << 31;
+        u32 p = u32(1 << 31);
 
         while (length > 0)
         {

--- a/source/mango/core/sha1.cpp
+++ b/source/mango/core/sha1.cpp
@@ -266,7 +266,7 @@ namespace
         // Load initial hash values
         __m128i abcd = _mm_loadu_si128(reinterpret_cast<__m128i*>(digest));
         __m128i e0   = _mm_setzero_si128();
-        e0   = _mm_insert_epi32(e0, digest[4], 3);
+        e0   = _mm_insert_epi32(e0, int(digest[4]), 3);
         abcd = _mm_shuffle_epi32(abcd, 0x1b);
         e0   = _mm_and_si128(e0, e_mask);
 
@@ -424,7 +424,7 @@ namespace
 
         abcd = _mm_shuffle_epi32(abcd, 0x1b);
         _mm_storeu_si128(reinterpret_cast<__m128i*>(digest), abcd);
-        digest[4] = _mm_extract_epi32(e0, 3);
+        digest[4] = u32(_mm_extract_epi32(e0, 3));
     }
 
 #endif
@@ -600,7 +600,7 @@ namespace mango
         u32 size = u32(memory.size);
         const u8* data = memory.address;
 
-        const int block_count = size / 64;
+        const int block_count = int(size / 64);
         transform(hash.data, data, block_count);
         data += block_count * 64;
         size -= block_count * 64;

--- a/source/mango/core/string.cpp
+++ b/source/mango/core/string.cpp
@@ -127,7 +127,7 @@ namespace
 
         if (code < 0x80)
         {
-            *ptr++ = code;
+            *ptr++ = char(code);
         }
         else if (code < 0x800)
         {
@@ -241,7 +241,7 @@ namespace mango
                 // encode into temporary buffer
                 if (code <= 0xffff)
                 {
-                    *sb.ptr++ = code;
+                    *sb.ptr++ = char16_t(code);
                 }
                 else
                 {
@@ -327,7 +327,7 @@ namespace mango
 
             if (c < 0x80)
             {
-                s.push_back(c);
+                s.push_back(char(c));
             }
             else if (c < 0x800)
             {
@@ -370,7 +370,7 @@ namespace mango
                 if (code <= 0xffff)
                 {
                     sb.ensure();
-                    *sb.ptr++ = code;
+                    *sb.ptr++ = wchar_t(code);
                 }
             }
         }
@@ -426,7 +426,7 @@ namespace mango
             }
             else
             {
-                s.push_back(d);
+                s.push_back(wchar_t(d));
             }
         }
 
@@ -440,13 +440,21 @@ namespace mango
 
     std::string toLower(std::string s)
     {
-        std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+        std::transform(s.begin(), s.end(), s.begin(), [] (unsigned char c)
+        {
+            return char(std::tolower(c));
+        });
+
         return s;
     }
 
     std::string toUpper(std::string s)
     {
-        std::transform(s.begin(), s.end(), s.begin(), ::toupper);
+        std::transform(s.begin(), s.end(), s.begin(), [] (unsigned char c)
+        {
+            return char(std::toupper(c));
+        });
+
         return s;
     }
 

--- a/source/mango/core/string.cpp
+++ b/source/mango/core/string.cpp
@@ -577,10 +577,10 @@ namespace mango
             p += 16;
         }
 
-        for (size_t i = 0; i < count; ++i)
+        for (size_t index = 0; index < count; ++index)
         {
-            if (p[i] == value)
-                return p + i;
+            if (p[index] == value)
+                return p + index;
         }
 
         return nullptr;
@@ -595,6 +595,31 @@ namespace mango
     }
 
 #endif
+
+    // ----------------------------------------------------------------------------
+    // stringLength()
+    // ----------------------------------------------------------------------------
+
+    // strnlen, strnlen_s and others are not well supported by all compiler and is
+    // generally a hassle to choose which one to use with different tool-chains.
+    //
+    // Let's just re-invent the wheel and forget this ever happened.
+
+    size_t stringLength(const char* s, size_t maxlen)
+    {
+        if (!s)
+        {
+            return 0;
+        }
+
+        for (size_t i = 0; i < maxlen ; ++i)
+        {
+            if (s[i] == 0)
+                return i;
+        }
+
+        return maxlen;
+    }
 
     float parseFloat(std::string_view s)
     {

--- a/source/mango/core/string.cpp
+++ b/source/mango/core/string.cpp
@@ -612,13 +612,9 @@ namespace mango
             return 0;
         }
 
-        for (size_t i = 0; i < maxlen ; ++i)
-        {
-            if (s[i] == 0)
-                return i;
-        }
-
-        return maxlen;
+        const u8* p0 = reinterpret_cast<const u8*>(s);
+        const u8* p1 = memchr(p0, 0, maxlen);
+        return p1 ? p1 - p0 : maxlen;
     }
 
     float parseFloat(std::string_view s)

--- a/source/mango/core/thread.cpp
+++ b/source/mango/core/thread.cpp
@@ -112,9 +112,10 @@ namespace mango
     ThreadPool::ThreadPool(size_t size)
         : m_queue(nullptr)
         , m_threads(size)
-        , m_static_queue(this, "static")
+        , m_static_queue(nullptr, "static")
     {
         m_queue = new TaskQueue;
+        m_static_queue.pool = this;
 
         // NOTE: let OS scheduler shuffle tasks as it sees fit
         //       this gives better performance overall UNTIL we have some practical

--- a/source/mango/filesystem/mapper_rar.cpp
+++ b/source/mango/filesystem/mapper_rar.cpp
@@ -1,6 +1,6 @@
 /*
     MANGO Multimedia Development Platform
-    Copyright (C) 2012-2023 Twilight Finland 3D Oy Ltd. All rights reserved.
+    Copyright (C) 2012-2024 Twilight Finland 3D Oy Ltd. All rights reserved.
 */
 /*
     RAR decompression code: Alexander L. Roshal / unRAR library.
@@ -258,7 +258,7 @@ namespace
 
             if (flags & 0x8000 && type != FILE_HEAD)
             {
-                size += p.read32();
+                size = u16(size + p.read32());
             }
 
             switch (type)
@@ -618,8 +618,8 @@ namespace mango::filesystem
             file.packed_size = compressed_data.size;
             file.unpacked_size = unpacked_size;
             file.crc = crc;
-            file.version = algorithm;
-            file.method  = method;
+            file.version = u8(algorithm);
+            file.method  = u8(method);
             file.is_rar5 = true;
 
             file.folder = is_directory;

--- a/source/mango/filesystem/mapper_zip.cpp
+++ b/source/mango/filesystem/mapper_zip.cpp
@@ -284,12 +284,12 @@ namespace
                     case 0x9901:
                     {
                         // AES header
-                        u16 version = e.read16();
-                        u16 magic = e.read16(); // must be 'AE' (0x41, 0x45)
+                        u16 aes_version = e.read16();
+                        u16 aes_magic = e.read16(); // must be 'AE' (0x41, 0x45)
                         u8 mode = e.read8();
                         compression = e.read8(); // override compression algorithm
 
-                        if (version < 1 || version > 2 || magic != 0x4541)
+                        if (aes_version < 1 || aes_version > 2 || aes_magic != 0x4541)
                         {
                             MANGO_EXCEPTION("[mapper.zip] Incorrect AES header.");
                         }

--- a/source/mango/filesystem/win32/file_observer.cpp
+++ b/source/mango/filesystem/win32/file_observer.cpp
@@ -20,6 +20,8 @@ namespace mango::filesystem
 
     static void processNotify(FileObserver* observer, BYTE* buffer, DWORD bytes, u32 flags0)
     {
+        MANGO_UNREFERENCED(bytes);
+
         for (; buffer;)
         {
             FILE_NOTIFY_INFORMATION* notify = (FILE_NOTIFY_INFORMATION*)(buffer);

--- a/source/mango/image/block.cpp
+++ b/source/mango/image/block.cpp
@@ -1588,27 +1588,27 @@ namespace mango::image
         return (compression & SRGB) == 0;
     }
 
-    int TextureCompression::getBlocksX(int width) const
+    int TextureCompression::getBlocksX(int c_width) const
     {
-        return div_ceil(width, this->width);
+        return div_ceil(c_width, width);
     }
 
-    int TextureCompression::getBlocksY(int height) const
+    int TextureCompression::getBlocksY(int c_height) const
     {
-        return div_ceil(height, this->height);
+        return div_ceil(c_height, height);
     }
 
-    int TextureCompression::getBlockCount(int width, int height) const
+    int TextureCompression::getBlockCount(int c_width, int c_height) const
     {
-        int xblocks = getBlocksX(width);
-        int yblocks = getBlocksY(height);
+        int xblocks = getBlocksX(c_width);
+        int yblocks = getBlocksY(c_height);
         return xblocks * yblocks;
     }
 
-    u64 TextureCompression::getBlockBytes(int width, int height) const
+    u64 TextureCompression::getBlockBytes(int c_width, int c_height) const
     {
-        int xblocks = getBlocksX(width);
-        int yblocks = getBlocksY(height);
+        int xblocks = getBlocksX(c_width);
+        int yblocks = getBlocksY(c_height);
         return xblocks * yblocks * bytes;
     }
 

--- a/source/mango/image/block_astc.cpp
+++ b/source/mango/image/block_astc.cpp
@@ -85,8 +85,8 @@ namespace mango::image
         else
         {
             u32 thread_index = 0;
-            auto status = astcenc_compress_image(context, &image, &swizzle, output, output_bytes, thread_index);
-            if (status != ASTCENC_SUCCESS)
+            auto status2 = astcenc_compress_image(context, &image, &swizzle, output, output_bytes, thread_index);
+            if (status2 != ASTCENC_SUCCESS)
             {
                 printLine(Print::Error, "[ASTC] astcenc_compress_image: {}", astcenc_get_error_string(status));
             }

--- a/source/mango/image/block_dxt.cpp
+++ b/source/mango/image/block_dxt.cpp
@@ -125,10 +125,10 @@ namespace
 
         for (int y = 0; y < 4; ++y)
         {
-            dest[0]  = u32_extend((data >>  0) & 0xf, 4, 8);
-            dest[4]  = u32_extend((data >>  4) & 0xf, 4, 8);
-            dest[8]  = u32_extend((data >>  8) & 0xf, 4, 8);
-            dest[12] = u32_extend((data >> 12) & 0xf, 4, 8);
+            dest[0]  = u8_extend((data >>  0) & 0xf, 4, 8);
+            dest[4]  = u8_extend((data >>  4) & 0xf, 4, 8);
+            dest[8]  = u8_extend((data >>  8) & 0xf, 4, 8);
+            dest[12] = u8_extend((data >> 12) & 0xf, 4, 8);
             data >>= 16;
             dest += stride;
         }
@@ -160,10 +160,10 @@ namespace
         for (int y = 0; y < 4; ++y)
         {
             u32 data = littleEndian::uload16(&alphaBlock->data[y]);
-            dest[0]  = u32_extend((data >>  0) & 0xf, 4, 8);
-            dest[4]  = u32_extend((data >>  4) & 0xf, 4, 8);
-            dest[8]  = u32_extend((data >>  8) & 0xf, 4, 8);
-            dest[12] = u32_extend((data >> 12) & 0xf, 4, 8);
+            dest[0]  = u8_extend((data >>  0) & 0xf, 4, 8);
+            dest[4]  = u8_extend((data >>  4) & 0xf, 4, 8);
+            dest[8]  = u8_extend((data >>  8) & 0xf, 4, 8);
+            dest[12] = u8_extend((data >> 12) & 0xf, 4, 8);
             dest += stride;
         }
     }
@@ -210,14 +210,14 @@ namespace
             color[ 2] = 0;
             color[ 3] = 0xff;
 
-            color[ 8] = u32_extend((a >>  0) & 0x1f, 5, 8);
-            color[ 9] = u32_extend((a >>  5) & 0x1f, 5, 8);
-            color[10] = u32_extend((a >> 10) & 0x1f, 5, 8);
+            color[ 8] = u8_extend((a >>  0) & 0x1f, 5, 8);
+            color[ 9] = u8_extend((a >>  5) & 0x1f, 5, 8);
+            color[10] = u8_extend((a >> 10) & 0x1f, 5, 8);
             color[11] = 0xff;
 
-            color[12] = u32_extend((b >>  0) & 0x1f, 5, 8);
-            color[13] = u32_extend((b >>  5) & 0x3f, 6, 8);
-            color[14] = u32_extend((b >> 11) & 0x1f, 5, 8);
+            color[12] = u8_extend((b >>  0) & 0x1f, 5, 8);
+            color[13] = u8_extend((b >>  5) & 0x3f, 6, 8);
+            color[14] = u8_extend((b >> 11) & 0x1f, 5, 8);
             color[15] = 0xff;
 
             color[ 4] = color[ 8] - color[12] / 4;
@@ -227,14 +227,14 @@ namespace
         }
         else
         {
-            color[ 0] = u32_extend((a >>  0) & 0x1f, 5, 8);
-            color[ 1] = u32_extend((a >>  5) & 0x1f, 5, 8);
-            color[ 2] = u32_extend((a >> 10) & 0x1f, 5, 8);
+            color[ 0] = u8_extend((a >>  0) & 0x1f, 5, 8);
+            color[ 1] = u8_extend((a >>  5) & 0x1f, 5, 8);
+            color[ 2] = u8_extend((a >> 10) & 0x1f, 5, 8);
             color[ 3] = 0xff;
 
-            color[12] = u32_extend((b >>  0) & 0x1f, 5, 8);
-            color[13] = u32_extend((b >>  5) & 0x3f, 6, 8);
-            color[14] = u32_extend((b >> 11) & 0x1f, 5, 8);
+            color[12] = u8_extend((b >>  0) & 0x1f, 5, 8);
+            color[13] = u8_extend((b >>  5) & 0x3f, 6, 8);
+            color[14] = u8_extend((b >> 11) & 0x1f, 5, 8);
             color[15] = 0xff;
 
             color[ 4] = (2 * color[0] + color[12]) / 3;

--- a/source/mango/image/block_fxt1.cpp
+++ b/source/mango/image/block_fxt1.cpp
@@ -154,6 +154,8 @@ namespace
 
     void decode_chroma(u8* out, size_t stride, const BlockCHROMA& block, u8 alphaMask)
     {
+        MANGO_UNREFERENCED(alphaMask);
+
         u32 b0 = expand5to8(block.blue0);
         u32 g0 = expand5to8(block.green0);
         u32 r0 = expand5to8(block.red0);

--- a/source/mango/image/block_fxt1.cpp
+++ b/source/mango/image/block_fxt1.cpp
@@ -19,7 +19,7 @@ namespace
         u32 getMode() const
         {
             // mode is stored in the 3 last bits of FXT block
-            return data[15] >> 5;
+            return u32(data[15] >> 5);
         }
     };
 
@@ -277,8 +277,8 @@ namespace
 
         if (!block.alpha)
         {
-            u32 bit01 = (block.indices[0] >> 1) & 1;
-            u32 bit33 = (block.indices[4] >> 1) & 1;
+            u32 bit01 = u32((block.indices[0] >> 1) & 1);
+            u32 bit33 = u32((block.indices[4] >> 1) & 1);
 
             u32 b0 = expand5to8(block.blue0);
             u32 g0 = expand5to8(u32(block.green0 << 1) | u32(block.lsb1 ^ bit01));

--- a/source/mango/image/block_pvrtc.cpp
+++ b/source/mango/image/block_pvrtc.cpp
@@ -224,7 +224,7 @@ namespace
                     const int s = y & 1;
                     for (int x = 0; x < 4; x++)
                     {
-                        dest[1 - s] = WordModMode;
+                        dest[1 - s] = u8(WordModMode);
                         dest[0 + s] = modulation_table[ModulationBits & 3];
                         dest += 2;
                         ModulationBits >>= 2;
@@ -560,29 +560,31 @@ namespace
 
             if (opacity)
             {
-                a.b = pvrtc2_extend((packed >>  1) & 0x0f, 4, 8);
-                a.g = pvrtc2_extend((packed >>  5) & 0x1f, 5, 8);
-                a.r = pvrtc2_extend((packed >> 10) & 0x1f, 5, 8);
-                a.a = 0xff;
+                u32 b0 = pvrtc2_extend((packed >>  1) & 0x0f, 4, 8);
+                u32 g0 = pvrtc2_extend((packed >>  5) & 0x1f, 5, 8);
+                u32 r0 = pvrtc2_extend((packed >> 10) & 0x1f, 5, 8);
+                a = Color(r0, g0, b0, 0xff);
 
-                b.b = pvrtc2_extend((packed >> 16) & 0x1f, 5, 8);
-                b.g = pvrtc2_extend((packed >> 21) & 0x1f, 5, 8);
-                b.r = pvrtc2_extend((packed >> 26) & 0x1f, 5, 8);
-                b.a = 0xff;
+                u32 b1 = pvrtc2_extend((packed >> 16) & 0x1f, 5, 8);
+                u32 g1 = pvrtc2_extend((packed >> 21) & 0x1f, 5, 8);
+                u32 r1 = pvrtc2_extend((packed >> 26) & 0x1f, 5, 8);
+                b = Color(r1, g1, b1, 0xff);
             }
             else
             {
-                a.b = pvrtc2_extend((packed >>  1) & 0x07, 3, 8);
-                a.g = pvrtc2_extend((packed >>  4) & 0x0f, 4, 8);
-                a.r = pvrtc2_extend((packed >>  8) & 0x0f, 4, 8);
-                //a.a = pvrtc2_alpha1((packed >> 12) & 0x07);
-                a.a = pvrtc2_extend((packed >> 12) & 0x07, 3, 8);
+                u32 b0 = pvrtc2_extend((packed >>  1) & 0x07, 3, 8);
+                u32 g0 = pvrtc2_extend((packed >>  4) & 0x0f, 4, 8);
+                u32 r0 = pvrtc2_extend((packed >>  8) & 0x0f, 4, 8);
+                //u32 a0 = pvrtc2_alpha1((packed >> 12) & 0x07);
+                u32 a0 = pvrtc2_extend((packed >> 12) & 0x07, 3, 8);
+                a = Color(r0, g0, b0, a0);
 
-                b.b = pvrtc2_extend((packed >> 16) & 0xf, 4, 8);
-                b.g = pvrtc2_extend((packed >> 20) & 0xf, 4, 8);
-                b.r = pvrtc2_extend((packed >> 24) & 0xf, 4, 8);
-                //b.a = pvrtc2_alpha0((packed >> 28) & 0x7);
-                b.a = pvrtc2_extend((packed >> 28) & 0x7, 3, 8);
+                u32 b1 = pvrtc2_extend((packed >> 16) & 0xf, 4, 8);
+                u32 g1 = pvrtc2_extend((packed >> 20) & 0xf, 4, 8);
+                u32 r1 = pvrtc2_extend((packed >> 24) & 0xf, 4, 8);
+                //u32 a1 = pvrtc2_alpha0((packed >> 28) & 0x7);
+                u32 a1 = pvrtc2_extend((packed >> 28) & 0x7, 3, 8);
+                b = Color(r1, g1, b1, a1);
             }
         }
 

--- a/source/mango/image/format.cpp
+++ b/source/mango/image/format.cpp
@@ -228,7 +228,7 @@ namespace mango::image
     {
     }
 
-    LuminanceFormat::LuminanceFormat(int bits, Type type, u8 luminanceBits, u8 alphaBits, u16 flags)
+    LuminanceFormat::LuminanceFormat(int bits, Type type, u32 luminanceBits, u32 alphaBits, u16 flags)
         : Format(bits, type, Color(luminanceBits, luminanceBits, luminanceBits, alphaBits), Color(0, 0, 0, luminanceBits), flags | LUMINANCE)
     {
     }

--- a/source/mango/image/image.cpp
+++ b/source/mango/image/image.cpp
@@ -171,12 +171,14 @@ namespace mango::image
 
         void registerImageDecoder(ImageDecoder::CreateDecodeFunc func, const std::string& extension)
         {
-            m_decoders[toLower(extension)] = func;
+            std::string s = toLower(extension);
+            m_decoders[s] = func;
         }
 
         void registerImageEncoder(ImageEncoder::EncodeFunc func, const std::string& extension)
         {
-            m_encoders[toLower(extension)] = func;
+            std::string s = toLower(extension);
+            m_encoders[s] = func;
         }
 
         ImageDecoder::CreateDecodeFunc getImageDecoder(const std::string& extension) const

--- a/source/mango/image/image_avif.cpp
+++ b/source/mango/image/image_avif.cpp
@@ -86,6 +86,7 @@ namespace
 
         ImageDecodeStatus decode(const Surface& dest, const ImageDecodeOptions& options, int level, int depth, int face) override
         {
+            MANGO_UNREFERENCED(options);
             MANGO_UNREFERENCED(level);
             MANGO_UNREFERENCED(depth);
             MANGO_UNREFERENCED(face);
@@ -175,6 +176,8 @@ namespace
 
     ImageEncodeStatus imageEncode(Stream& output, const Surface& surface, const ImageEncodeOptions& options)
     {
+        MANGO_UNREFERENCED(options);
+
         ImageEncodeStatus status;
 
         int width = surface.width;

--- a/source/mango/image/image_bmp.cpp
+++ b/source/mango/image/image_bmp.cpp
@@ -247,7 +247,7 @@ namespace
             printLine(Print::Info, "  profile data: {}, size: {}", profileData, profileSize);
         }
 
-        void OS2BitmapHeader1(LittleEndianConstPointer& p, int headerSize)
+        void OS2BitmapHeader1(LittleEndianConstPointer& p)
         {
             printLine(Print::Info, "[OS2BitmapHeader1]");
 
@@ -305,7 +305,7 @@ namespace
             {
                 case 12:
                 {
-                    OS2BitmapHeader1(p, headerSize);
+                    OS2BitmapHeader1(p);
                     paletteComponents = 3;
                     os2 = true;
                     break;
@@ -313,7 +313,7 @@ namespace
 
                 case 16:
                 {
-                    OS2BitmapHeader1(p, headerSize);
+                    OS2BitmapHeader1(p);
                     OS2BitmapHeader2(p);
                     paletteComponents = 4;
                     os2 = true;
@@ -1072,8 +1072,8 @@ namespace
                 p += 4;
             }
 
-            int size = p.read32();
-            int offset = p.read32();
+            int c_size = p.read32();
+            int c_offset = p.read32();
 
             if (!width)
             {
@@ -1096,8 +1096,8 @@ namespace
             if (score > bestScore)
             {
                 bestScore = score;
-                bestOffset = offset;
-                bestSize = size;
+                bestOffset = c_offset;
+                bestSize = c_size;
                 bestColors = colors;
             }
         }
@@ -1118,21 +1118,21 @@ namespace
         {
             case 0x28:
             {
-                BitmapHeader header(block, true);
-                if (!header)
+                BitmapHeader bitmap_header(block, true);
+                if (!bitmap_header)
                 {
                     return "[ImageDecoder.BMP] Incorrect ICO/CUR header.";
                 }
 
                 if (imageHeader)
                 {
-                    imageHeader->width   = header.width;
-                    imageHeader->height  = header.height;
+                    imageHeader->width   = bitmap_header.width;
+                    imageHeader->height  = bitmap_header.height;
                     imageHeader->depth   = 0;
                     imageHeader->levels  = 0;
                     imageHeader->faces   = 0;
                     imageHeader->palette = false;
-                    imageHeader->format  = header.format;
+                    imageHeader->format  = bitmap_header.format;
                     imageHeader->compression = TextureCompression::NONE;
                 }
 

--- a/source/mango/image/image_dds.cpp
+++ b/source/mango/image/image_dds.cpp
@@ -1107,7 +1107,7 @@ namespace
             return ysize * pitch;
         }
 
-        ConstMemory getMemory(int level, int depth, int face) const
+        ConstMemory getMemory(int c_level, int c_depth, int c_face) const
         {
             const int maxFace = getFaceCount();
             const int maxLevel = getMipmapCount();
@@ -1120,7 +1120,7 @@ namespace
             {
                 for (int iFace = 0; iFace < maxFace; ++iFace)
                 {
-                    bool isDepthFace = (depth == iDepth) && (face == iFace);
+                    bool isDepthFace = (c_depth == iDepth) && (c_face == iFace);
 
                     for (int iLevel = 0; iLevel < maxLevel; ++iLevel)
                     {
@@ -1128,7 +1128,7 @@ namespace
                         const int ysize = std::max(1, int(height) >> iLevel);
                         const int bytes = getLevelSize(xsize, ysize);
 
-                        if (isDepthFace && iLevel == level)
+                        if (isDepthFace && iLevel == c_level)
                         {
                             // Store selected address
                             selected = ConstMemory(image, bytes);

--- a/source/mango/image/image_exr.cpp
+++ b/source/mango/image/image_exr.cpp
@@ -613,36 +613,36 @@ void hufFreeDecTable(HufDec *hdecod)
 //
 
 #define getChar(c, lc, in) \
-{ \
+{                                 \
     c = (c << 8) | *(u8 *)(in++); \
-    lc += 8; \
+    lc += 8;                      \
 }
 
 #define getCode(po, rlc, c, lc, in, out, ob, oe) \
-{ \
-    if (po == rlc) \
-    { \
-        if (lc < 8) \
+{                               \
+    if (po == rlc)              \
+    {                           \
+        if (lc < 8)             \
             getChar(c, lc, in); \
-        \
-        lc -= 8; \
-        \
-        u8 cs = (c >> lc); \
-        \
-        /*if (out + cs > oe) \
-            ; \
-        else if (out - 1 < ob) \
-            ;*/ \
-        \
-        u16 s = out[-1]; \
-        \
-        while (cs-- > 0) \
-            *out++ = s; \
-    } \
-    else if (out < oe) \
-    { \
-        *out++ = po; \
-    } \
+                                \
+        lc -= 8;                \
+                                \
+        u8 cs = (c >> lc);      \
+                                \
+        /*if (out + cs > oe)    \
+            ;                   \
+        else if (out - 1 < ob)  \
+            ;*/                 \
+                                \
+        u16 s = out[-1];        \
+                                \
+        while (cs-- > 0)        \
+            *out++ = s;         \
+    }                           \
+    else if (out < oe)          \
+    {                           \
+        *out++ = u16(po);       \
+    }                           \
 }
 
 //
@@ -860,7 +860,7 @@ u16 reverseLutFromBitmap(const u8 bitmap[BITMAP_SIZE], u16 lut[USHORT_RANGE])
         lut[k] = 0;
     }
 
-    return n; // maximum k where lut[k] is non-zero
+    return u16(n); // maximum k where lut[k] is non-zero
 }
 
 static
@@ -1418,10 +1418,12 @@ struct AttributeTable
     Text        view;
 
     // Multi-Part Data Header Attributes
+    /*
     String      name;
     String      type;
     u32         version;
     u32         chunkCount;
+    */
 
     // Deep Data Header Attributes
     u32         maxSamplesPerPixel;
@@ -1433,6 +1435,9 @@ struct AttributeTable
 
     void parse(const std::string& name, const std::string& type, LittleEndianConstPointer p, u32 size)
     {
+        MANGO_UNREFERENCED(type);
+        MANGO_UNREFERENCED(size);
+
         if (name == "channels")
         {
             readAttribute(chlist, p);
@@ -1532,7 +1537,7 @@ struct ContextEXR
         for (u32 i = 0; i < 0x10000; ++i)
         {
             float16 hf;
-            hf.u = i;
+            hf.u = u16(i);
 
             u16 value = 0;
 
@@ -1713,6 +1718,7 @@ ContextEXR::~ContextEXR()
 
 const u8* ContextEXR::decompress_none(Memory dest, ConstMemory source)
 {
+    MANGO_UNREFERENCED(dest);
     return source.address;
 }
 
@@ -2803,6 +2809,9 @@ void ContextEXR::decodeImage(const ImageDecodeOptions& options)
 
 ImageDecodeStatus ContextEXR::decode(const Surface& dest, const ImageDecodeOptions& options, int level, int depth, int face)
 {
+    MANGO_UNREFERENCED(level);
+    MANGO_UNREFERENCED(depth);
+
     ImageDecodeStatus status;
 
     if (!m_pointer)
@@ -2854,6 +2863,9 @@ namespace
 
         ConstMemory memory(int level, int depth, int face) override
         {
+            MANGO_UNREFERENCED(level);
+            MANGO_UNREFERENCED(depth);
+            MANGO_UNREFERENCED(face);
             return ConstMemory();
         }
 

--- a/source/mango/image/image_gif.cpp
+++ b/source/mango/image/image_gif.cpp
@@ -145,7 +145,7 @@ namespace
 
         for (int i = 0; i < code_clear; ++i)
         {
-            const u8 initcode = i;
+            const u8 initcode = u8(i);
             codes[i].prefix = -1;
             codes[i].first = initcode;
             codes[i].suffix = initcode;
@@ -178,7 +178,8 @@ namespace
                     if (src + length >= src_end)
                     {
                         // overflow
-                        return nullptr;
+                        src = nullptr;
+                        break;
                     }
                 }
 
@@ -220,7 +221,8 @@ namespace
                         if (available >= MAX_STACK_SIZE)
                         {
                             // too many codes
-                            return nullptr;
+                            src = nullptr;
+                            break;
                         }
 
                         p->prefix = s16(oldcode);
@@ -230,7 +232,8 @@ namespace
                     else if (code == available)
                     {
                         // illegal code
-                        return nullptr;
+                        src = nullptr;
+                        break;
                     }
 
                     oldcode = code;
@@ -265,7 +268,8 @@ namespace
                 else
                 {
                     // illegal code
-                    return nullptr;
+                    src = nullptr;
+                    break;
                 }
             }
         }
@@ -422,9 +426,9 @@ namespace
         Surface rect(surface, x, y, width, height);
         u8* src = bits.get();
 
-        for (int y = 0; y < rect.height; ++y)
+        for (int sy = 0; sy < rect.height; ++sy)
         {
-            u8* dest = rect.address<u8>(0, y);
+            u8* dest = rect.address<u8>(0, sy);
             func(dest, src, rect.width, palette, transparent);
             src += width;
         }

--- a/source/mango/image/image_heif.cpp
+++ b/source/mango/image/image_heif.cpp
@@ -113,6 +113,7 @@ namespace
 
         ImageDecodeStatus decode(const Surface& dest, const ImageDecodeOptions& options, int level, int depth, int face) override
         {
+            MANGO_UNREFERENCED(options);
             MANGO_UNREFERENCED(level);
             MANGO_UNREFERENCED(depth);
             MANGO_UNREFERENCED(face);

--- a/source/mango/image/image_jp2.cpp
+++ b/source/mango/image/image_jp2.cpp
@@ -671,7 +671,7 @@ namespace
                 return;
             }
 
-            CallbackManager callback(m_codec, 0);
+            CallbackManager callback_manager(m_codec, 0);
 
             size_t num_thread = std::max(std::thread::hardware_concurrency(), 1u);
             opj_codec_set_threads(m_codec, int(num_thread));

--- a/source/mango/image/image_jpg.cpp
+++ b/source/mango/image/image_jpg.cpp
@@ -24,6 +24,7 @@ namespace
             : m_parser(memory)
         {
             m_parser.setInterface(this);
+
             async = true;
             header = m_parser.header;
             icc = m_parser.icc_buffer;

--- a/source/mango/image/image_jpg.cpp
+++ b/source/mango/image/image_jpg.cpp
@@ -21,8 +21,9 @@ namespace
         jpeg::Parser m_parser;
 
         Interface(ConstMemory memory)
-            : m_parser(memory, this)
+            : m_parser(memory)
         {
+            m_parser.setInterface(this);
             async = true;
             header = m_parser.header;
             icc = m_parser.icc_buffer;

--- a/source/mango/image/image_pcx.cpp
+++ b/source/mango/image/image_pcx.cpp
@@ -140,7 +140,7 @@ namespace
                 if (src[sn * 1] & mask) index |= 2;
                 if (src[sn * 2] & mask) index |= 4;
                 if (src[sn * 3] & mask) index |= 8;
-                image[x] = index;
+                image[x] = u8(index);
             }
 
             buffer += scansize;

--- a/source/mango/image/image_pic.cpp
+++ b/source/mango/image/image_pic.cpp
@@ -73,11 +73,19 @@ namespace
 
         ConstMemory memory(int level, int depth, int face) override
         {
+            MANGO_UNREFERENCED(level);
+            MANGO_UNREFERENCED(depth);
+            MANGO_UNREFERENCED(face);
             return ConstMemory();
         }
 
         ImageDecodeStatus decode(const Surface& dest, const ImageDecodeOptions& options, int level, int depth, int face) override
         {
+            MANGO_UNREFERENCED(options);
+            MANGO_UNREFERENCED(level);
+            MANGO_UNREFERENCED(depth);
+            MANGO_UNREFERENCED(face);
+
             ImageDecodeStatus status;
 
             const u8* end = m_data.end();
@@ -141,22 +149,22 @@ namespace
 
             for (int y = 0; y < height; ++y)
             {
-                u8* dest = temp.address<u8>(0, y);
+                u8* dst = temp.address<u8>(0, y);
 
                 for (const Packet& packet : packets)
                 {
                     switch (packet.type)
                     {
                         case 0:
-                            p = decode_uncompressed(dest, p, width, packet.mask);
+                            p = decode_uncompressed(dst, p, width, packet.mask);
                             break;
 
                         case 1:
-                            p = decode_runlength(dest, p, width, packet.mask);
+                            p = decode_runlength(dst, p, width, packet.mask);
                             break;
 
                         case 2:
-                            p = decode_mixed(dest, p, width, packet.mask);
+                            p = decode_mixed(dst, p, width, packet.mask);
                             break;
                     }
                 }

--- a/source/mango/image/image_png.cpp
+++ b/source/mango/image/image_png.cpp
@@ -2399,6 +2399,7 @@ namespace
         }
 
         m_palette.size = size / 3;
+
         for (u32 i = 0; i < m_palette.size; ++i)
         {
             m_palette[i] = Color(p[0], p[1], p[2], 0xff);
@@ -3614,7 +3615,7 @@ namespace
 
                 auto decompress = deflate::decompress;
 
-                CompressionStatus result = decompress(buffer, memory);
+                CompressionStatus result = decompress(temp_memory, memory);
                 if (!result)
                 {
                     //printLine(Print::Info, "  {}", result.info);
@@ -3765,7 +3766,7 @@ namespace
     static
     void write_IHDR(Stream& stream, const Surface& surface, u8 color_bits, ColorType color_type)
     {
-        BufferStream buffer;
+        MemoryStream buffer;
         BigEndianStream s(buffer);
 
         s.write32(surface.width);
@@ -3782,7 +3783,7 @@ namespace
     static
     void write_PLTE(Stream& stream, const Palette& palette)
     {
-        BufferStream buffer;
+        MemoryStream buffer;
         BigEndianStream s(buffer);
 
         for (int i = 0; i < 256; ++i)
@@ -3804,7 +3805,7 @@ namespace
             return;
         }
 
-        BufferStream buffer;
+        MemoryStream buffer;
         BigEndianStream s(buffer);
 
         s.write8('-'); // profile name is 1-79 char according to spec. we dont have/need name
@@ -3824,7 +3825,7 @@ namespace
     static
     void write_pLLD(Stream& stream, int segment_height)
     {
-        BufferStream buffer;
+        MemoryStream buffer;
         BigEndianStream s(buffer);
 
         s.write32(segment_height);

--- a/source/mango/image/image_png.cpp
+++ b/source/mango/image/image_png.cpp
@@ -330,24 +330,6 @@ namespace
     }
 
     // ------------------------------------------------------------
-    // png_strnlen
-    // ------------------------------------------------------------
-
-    // Long story short; the strnlen() is not part of std and not available
-    // on all platforms or tool-chains so we have to wrap it like this. :(
-
-    static inline
-    size_t png_strnlen(const char* s, size_t maxlen)
-    {
-        for (size_t i = 0; i < maxlen ; ++i)
-        {
-            if (s[i] == 0)
-                return i;
-        }
-        return maxlen;
-    }
-
-    // ------------------------------------------------------------
     // Filter
     // ------------------------------------------------------------
 
@@ -2572,7 +2554,7 @@ namespace
         Compressed profile: n bytes
         */
         const char* name = reinterpret_cast<const char*>(&p[0]);
-        size_t name_len = png_strnlen(name, size);
+        size_t name_len = stringLength(name, size);
         if (name_len == size)
         {
             printLine(Print::Info, "iCCP: profile name not terminated");

--- a/source/mango/image/image_png.cpp
+++ b/source/mango/image/image_png.cpp
@@ -3208,12 +3208,12 @@ namespace
         printLine(Print::Info, "  buffer bytes: {}", buffer_size);
 
         // allocate output buffer
-        Buffer temp_buffer(bytes_per_line + buffer_size + PNG_SIMD_PADDING);
+        Buffer temp(bytes_per_line + buffer_size + PNG_SIMD_PADDING);
 
         // zero scanline for filters at the beginning
-        std::memset(temp_buffer, 0, bytes_per_line);
+        std::memset(temp, 0, bytes_per_line);
 
-        Memory memory_buffer(temp_buffer + bytes_per_line, buffer_size);
+        Memory buffer(temp + bytes_per_line, buffer_size);
 
         // ----------------------------------------------------------------------
 
@@ -3236,12 +3236,12 @@ namespace
         size_t top_size = bytes_per_line * m_first_half_height;
 
         Memory top_buffer;
-        top_buffer.address = memory_buffer.address;
+        top_buffer.address = buffer.address;
         top_buffer.size = top_size;
 
         Memory bottom_buffer;
-        bottom_buffer.address = memory_buffer.address + top_size;
-        bottom_buffer.size = memory_buffer.size - top_size;
+        bottom_buffer.address = buffer.address + top_size;
+        bottom_buffer.size = buffer.size - top_size;
 
         ConstMemory top_memory = compressed_top;
         ConstMemory bottom_memory = compressed_bottom;
@@ -3272,7 +3272,7 @@ namespace
         MANGO_UNREFERENCED(bytes_out_bottom);
 
         // process image
-        process_image(target, memory_buffer);
+        process_image(target, buffer);
     }
 
     bool ParserPNG::decode_std(const Surface& target, ImageDecodeStatus& status)
@@ -3296,12 +3296,12 @@ namespace
         printLine(Print::Info, "  buffer bytes: {}", buffer_size);
 
         // allocate output buffer
-        Buffer temp_buffer(bytes_per_line + buffer_size + PNG_SIMD_PADDING);
+        Buffer temp(bytes_per_line + buffer_size + PNG_SIMD_PADDING);
 
         // zero scanline for filters at the beginning
-        std::memset(temp_buffer, 0, bytes_per_line);
+        std::memset(temp, 0, bytes_per_line);
 
-        Memory temp_memory(temp_buffer + bytes_per_line, buffer_size);
+        Memory buffer(temp + bytes_per_line, buffer_size);
 
         // ----------------------------------------------------------------------
 
@@ -3342,8 +3342,8 @@ namespace
                     return false;
                 }
 
-                state.next_out = temp_memory.address + state.total_out;
-                state.avail_out = u32(temp_memory.size - state.total_out);
+                state.next_out = buffer.address + state.total_out;
+                state.avail_out = u32(buffer.size - state.total_out);
 
                 int s = isal_inflate(&state);
 
@@ -3393,7 +3393,7 @@ namespace
                 if (!m_interlace)
                 {
                     int y1 = int(state.total_out / bytes_per_line);
-                    process_range(target, temp_memory.address + bytes_per_line * y0, y0, y1);
+                    process_range(target, buffer.address + bytes_per_line * y0, y0, y1);
                     y0 = y1;
                 }
 
@@ -3411,7 +3411,7 @@ namespace
             // process image
             if (m_interlace)
             {
-                process_image(target, temp_memory);
+                process_image(target, buffer);
             }
 
 #else
@@ -3459,8 +3459,8 @@ namespace
 
                 do
                 {
-                    stream.avail_out = uInt(temp_memory.size - stream.total_out);
-                    stream.next_out = temp_memory.address + stream.total_out;
+                    stream.avail_out = uInt(buffer.size - stream.total_out);
+                    stream.next_out = buffer.address + stream.total_out;
 
                     ret = inflate(&stream, Z_NO_FLUSH);
                     if (ret == Z_STREAM_ERROR || ret == Z_DATA_ERROR || ret == Z_MEM_ERROR)
@@ -3475,7 +3475,7 @@ namespace
                 if (!m_interlace)
                 {
                     int y1 = int(stream.total_out / bytes_per_line);
-                    process_range(target, temp_memory.address + bytes_per_line * y0, y0, y1);
+                    process_range(target, buffer.address + bytes_per_line * y0, y0, y1);
                     y0 = y1;
                 }
 
@@ -3499,7 +3499,7 @@ namespace
             // process image
             if (m_interlace)
             {
-                process_image(target, temp_memory);
+                process_image(target, buffer);
             }
 #endif
         }
@@ -3527,7 +3527,7 @@ namespace
 
             auto decompress = deflate::decompress;
 
-            CompressionStatus result = decompress(temp_memory, memory);
+            CompressionStatus result = decompress(buffer, memory);
             if (!result)
             {
                 //printLine(Print::Info, "  {}", result.info);
@@ -3543,7 +3543,7 @@ namespace
             }
 
             // process image
-            process_image(target, temp_memory);
+            process_image(target, buffer);
         }
 
         return true;

--- a/source/mango/image/image_psd.cpp
+++ b/source/mango/image/image_psd.cpp
@@ -384,6 +384,11 @@ namespace
 
         ImageDecodeStatus decode(const Surface& dest, const ImageDecodeOptions& options, int level, int depth, int face) override
         {
+            MANGO_UNREFERENCED(face);
+            MANGO_UNREFERENCED(depth);
+            MANGO_UNREFERENCED(level);
+            MANGO_UNREFERENCED(options);
+
             ImageDecodeStatus status;
 
             const u8* p = m_memory.address;
@@ -505,6 +510,8 @@ namespace
 
         void resolveBitmap(u8* dest, const u8* src, int width, int channels)
         {
+            MANGO_UNREFERENCED(channels);
+
             u8 mask = 0;
             u8 data = 0;
 

--- a/source/mango/image/image_psd.cpp
+++ b/source/mango/image/image_psd.cpp
@@ -305,6 +305,9 @@ namespace
 
         ConstMemory memory(int level, int depth, int face) override
         {
+            MANGO_UNREFERENCED(level);
+            MANGO_UNREFERENCED(face);
+            MANGO_UNREFERENCED(depth);
             return ConstMemory();
         }
 
@@ -341,7 +344,7 @@ namespace
                 }
 
                 u16 id = p.read16();
-                std::string name = parse_string(p, 2);
+                std::string c_name = parse_string(p, 2);
                 u32 length = p.read32();
 
                 bool supported = true;
@@ -415,8 +418,8 @@ namespace
                         for (int channel = 0; channel < channels; ++channel)
                         {
                             const u8* src = p + channel * bytes_per_channel + y * bytes_per_scan;
-                            u8* dest = buffer + channel * bytes_per_scan;
-                            std::memcpy(dest, src, bytes_per_scan);
+                            u8* dst = buffer + channel * bytes_per_scan;
+                            std::memcpy(dst, src, bytes_per_scan);
                         }
 
 #ifdef MANGO_LITTLE_ENDIAN
@@ -441,8 +444,8 @@ namespace
                             const u8* src = p + packbits.offsets[channel];
                             packbits.offsets[channel] += bytes;
 
-                            u8* dest = buffer + channel * bytes_per_scan;
-                            bool result = packbits.decompress(dest, src, bytes_per_scan, bytes);
+                            u8* dst = buffer + channel * bytes_per_scan;
+                            bool result = packbits.decompress(dst, src, bytes_per_scan, bytes);
                             if (!result)
                             {
                                 status.setError("[ImageDecoder.PSD] packbits decompression failed.");
@@ -536,6 +539,8 @@ namespace
 
         void resolveGrayscale(u8* dest, const u8* src, int width, int channels)
         {
+            MANGO_UNREFERENCED(channels);
+
             switch (m_bits)
             {
                 case 8:
@@ -552,6 +557,8 @@ namespace
 
         void resolveIndexed(u8* dest, const u8* src, int width, int channels)
         {
+            MANGO_UNREFERENCED(channels);
+
             if (m_bits == 8 && m_palette)
             {
                 for (int i = 0; i < width; ++i)
@@ -593,6 +600,8 @@ namespace
 
         void resolveCMYK(u8* dest, const u8* src, int width, int channels)
         {
+            MANGO_UNREFERENCED(channels);
+
             // MANGO TODO: 16, 32 bits
             // MANGO TODO: different nr of channels
             if (m_bits == 8)
@@ -615,6 +624,8 @@ namespace
 
         void resolveLab(u8* dest, const u8* src, int width, int channels)
         {
+            MANGO_UNREFERENCED(channels);
+
             if (m_bits == 8)
             {
                 for (int i = 0; i < width; ++i)

--- a/source/mango/image/image_pvr.cpp
+++ b/source/mango/image/image_pvr.cpp
@@ -55,7 +55,7 @@ namespace
 
             if (index >= 0)
             {
-                offset[index] = bits;
+                offset[index] = u8(bits);
                 size[index] = cc_size[i];
                 bits += cc_size[i];
             }
@@ -285,8 +285,8 @@ namespace
                 case 0x0A: // (V,Y1,U,Y0)
                     compression = TextureCompression::YUY2;
                     break;
-                    compression = TextureCompression::UYVY;
                 case 0x0B: // (Y1,V,Y0,U)
+                    compression = TextureCompression::UYVY;
                     break;
                 case 0x0C: // PVRTC2
                     compression = TextureCompression::PVRTC_RGBA_2BPP;

--- a/source/mango/image/image_qoi.cpp
+++ b/source/mango/image/image_qoi.cpp
@@ -179,7 +179,7 @@ namespace
 
     void qoi_decode(u8* image, const u8* data, size_t size, int width, int height, size_t stride)
     {
-        Color color(0, 0, 0, 255);
+        Color color(0, 0, 0, 0xff);
         Color cache[64] = { 0 };
 
         const u8* end = data + size;
@@ -229,9 +229,9 @@ namespace
                     {
                         int b2 = *data++;
                         int vg = (b1 & 0x3f) - 32;
-                        color.r += vg - 8 + ((b2 >> 4) & 0x0f);
-                        color.g += vg;
-                        color.b += vg - 8 +  (b2       & 0x0f);
+                        color.r = u8(color.r + vg - 8 + ((b2 >> 4) & 0x0f));
+                        color.g = u8(color.r + vg);
+                        color.b = u8(color.b + vg - 8 +  (b2       & 0x0f));
                     }
                     else if ((b1 & QOI_MASK_2) == QOI_OP_RUN)
                     {

--- a/source/mango/image/image_sgi.cpp
+++ b/source/mango/image/image_sgi.cpp
@@ -211,7 +211,6 @@ namespace
 
             ImageDecodeStatus status;
 
-            const ImageHeader& header = m_sgi_header.header;
             if (!header.success)
             {
                 status.setError(header.info);

--- a/source/mango/image/quantize.cpp
+++ b/source/mango/image/quantize.cpp
@@ -282,8 +282,8 @@ namespace
         {
             for (int j = 0; j < 3; ++j)
             {
-                constexpr int bias = 1 << (netbiasshift - 1);
-                network[i][j] = math::clamp((network[i][j] + bias) >> netbiasshift, 0, 255);
+                constexpr int c_bias = 1 << (netbiasshift - 1);
+                network[i][j] = math::clamp((network[i][j] + c_bias) >> netbiasshift, 0, 255);
             }
 
             network[i][3] = i;
@@ -313,10 +313,10 @@ namespace mango::image
 
         for (int i = 0; i < NETSIZE; ++i)
         {
-            m_palette.color[i].r = nq.network[i][0];
-            m_palette.color[i].g = nq.network[i][1];
-            m_palette.color[i].b = nq.network[i][2];
-            m_palette.color[i].a = 0xff;
+            int r = nq.network[i][0];
+            int g = nq.network[i][1];
+            int b = nq.network[i][2];
+            m_palette.color[i] = Color(r, g, b, 0xff);
 
             m_network[i][0] = nq.network[i][0];
             m_network[i][1] = nq.network[i][1];
@@ -385,8 +385,8 @@ namespace mango::image
                 int r = s[x].r;
                 int g = s[x].g;
                 int b = s[x].b;
-                u8 index = getIndex(r, g, b);
-                d[x] = index;
+                int index = getIndex(r, g, b);
+                d[x] = u8(index);
 
                 if (dithering)
                 {
@@ -397,9 +397,10 @@ namespace mango::image
 
                     const auto distribute = [] (Color& color, int r, int g, int b, int scale)
                     {
-                        color.r = math::clamp(color.r + (r * scale / 16), 0, 255);
-                        color.g = math::clamp(color.g + (g * scale / 16), 0, 255);
-                        color.b = math::clamp(color.b + (b * scale / 16), 0, 255);
+                        r = math::clamp(color.r + (r * scale / 16), 0, 255);
+                        g = math::clamp(color.g + (g * scale / 16), 0, 255);
+                        b = math::clamp(color.b + (b * scale / 16), 0, 255);
+                        color = Color(r, g, b, color.a);
                     };
 
                     // distribute the error to neighbouring pixels with Floyd-Steinberg weights

--- a/source/mango/image/surface.cpp
+++ b/source/mango/image/surface.cpp
@@ -546,9 +546,9 @@ namespace
         {
             switch (size)
             {
-                case 4: d[3] = color[3];
-                case 3: d[2] = color[2];
-                case 2: d[1] = color[1];
+                case 4: d[3] = color[3]; [[fallthrough]];
+                case 3: d[2] = color[2]; [[fallthrough]];
+                case 2: d[1] = color[1]; [[fallthrough]];
                 case 1: d[0] = color[0];
             }
             d += size;

--- a/source/mango/import3d/import_3ds.cpp
+++ b/source/mango/import3d/import_3ds.cpp
@@ -141,9 +141,9 @@ namespace
         std::string read_string(LittleEndianConstPointer& p) const
         {
             const u8* ptr = p;
-            const char* text = reinterpret_cast<const char*>(ptr);
-            p += strlen(text) + 1;
-            return text;
+            const char* txt = reinterpret_cast<const char*>(ptr);
+            p += strlen(txt) + 1;
+            return txt;
         }
 
         float32x3 read_vec3(LittleEndianConstPointer& p) const
@@ -218,6 +218,7 @@ namespace
         void chunk_main(LittleEndianConstPointer& p)
         {
             printLine(Print::Verbose, level * 2, "[main]");
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_version(LittleEndianConstPointer& p)
@@ -236,6 +237,7 @@ namespace
         void chunk_editor(LittleEndianConstPointer& p)
         {
             printLine(Print::Verbose, level * 2, "[editor]");
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_mesh_version(LittleEndianConstPointer& p)
@@ -251,6 +253,7 @@ namespace
             printLine(Print::Verbose, level * 2, "[material]");
 
             materials.emplace_back();
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_material_name(LittleEndianConstPointer& p)
@@ -331,6 +334,7 @@ namespace
             Material3DS& material = getCurrentMaterial();
             material.twosided = true;
             printLine(Print::Verbose, level * 2, "+ twosided");
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_material_additive(LittleEndianConstPointer& p)
@@ -338,6 +342,7 @@ namespace
             Material3DS& material = getCurrentMaterial();
             material.additive = true;
             printLine(Print::Verbose, level * 2, "+ additive");
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_material_self_illum_pct(LittleEndianConstPointer& p)
@@ -351,6 +356,7 @@ namespace
             Material3DS& material = getCurrentMaterial();
             material.wireframe = true;
             printLine(Print::Verbose, level * 2, "+ wireframe");
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_material_wireframe_size(LittleEndianConstPointer& p)
@@ -378,6 +384,7 @@ namespace
             printLine(Print::Verbose, level * 2, "[texture:map1]");
             Material3DS& material = getCurrentMaterial();
             texture = &material.texture_map1;
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_texture_map2(LittleEndianConstPointer& p)
@@ -385,6 +392,7 @@ namespace
             printLine(Print::Verbose, level * 2, "[texture:map2]");
             Material3DS& material = getCurrentMaterial();
             texture = &material.texture_map2;
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_texture_opacity(LittleEndianConstPointer& p)
@@ -392,6 +400,7 @@ namespace
             printLine(Print::Verbose, level * 2, "[texture:opacity]");
             Material3DS& material = getCurrentMaterial();
             texture = &material.texture_opacity;
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_texture_bump(LittleEndianConstPointer& p)
@@ -399,6 +408,7 @@ namespace
             printLine(Print::Verbose, level * 2, "[texture:bump]");
             Material3DS& material = getCurrentMaterial();
             texture = &material.texture_bump;
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_texture_specular(LittleEndianConstPointer& p)
@@ -406,6 +416,7 @@ namespace
             printLine(Print::Verbose, level * 2, "[texture:specular]");
             Material3DS& material = getCurrentMaterial();
             texture = &material.texture_specular;
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_texture_shininess(LittleEndianConstPointer& p)
@@ -413,6 +424,7 @@ namespace
             printLine(Print::Verbose, level * 2, "[texture:shininess]");
             Material3DS& material = getCurrentMaterial();
             texture = &material.texture_shininess;
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_texture_self_illum(LittleEndianConstPointer& p)
@@ -420,6 +432,7 @@ namespace
             printLine(Print::Verbose, level * 2, "[texture:self-illum]");
             Material3DS& material = getCurrentMaterial();
             texture = &material.texture_self_illum;
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_texture_reflection(LittleEndianConstPointer& p)
@@ -427,6 +440,7 @@ namespace
             printLine(Print::Verbose, level * 2, "[texture:reflection]");
             Material3DS& material = getCurrentMaterial();
             texture = &material.texture_reflection;
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_texture_map_name(LittleEndianConstPointer& p)
@@ -496,6 +510,7 @@ namespace
         {
             printLine(Print::Verbose, level * 2, "[mesh]");
             meshes.emplace_back();
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_mesh_vertex_list(LittleEndianConstPointer& p)
@@ -671,6 +686,7 @@ namespace
         void chunk_light_off(LittleEndianConstPointer& p)
         {
             // enable = false
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_light_spot_roll(LittleEndianConstPointer& p)
@@ -703,47 +719,55 @@ namespace
         void chunk_keyframer(LittleEndianConstPointer& p)
         {
             //printLine(Print::Verbose, level * 2, "[keyframer]");
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_key_ambient(LittleEndianConstPointer& p)
         {
             // TODO
             //printLine(Print::Verbose, level * 2, "[key.ambient]");
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_key_object(LittleEndianConstPointer& p)
         {
             //printLine(Print::Verbose, level * 2, "[key.object]");
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_key_camera(LittleEndianConstPointer& p)
         {
             // TODO
             //printLine(Print::Verbose, level * 2, "[key.camera]");
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_key_camera_target(LittleEndianConstPointer& p)
         {
             // TODO
             //printLine(Print::Verbose, level * 2, "[key.camera.target]");
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_key_light(LittleEndianConstPointer& p)
         {
             // TODO
             //printLine(Print::Verbose, level * 2, "[key.light]");
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_key_light_target(LittleEndianConstPointer& p)
         {
             // TODO
             //printLine(Print::Verbose, level * 2, "[key.light.target]");
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_key_spotlight(LittleEndianConstPointer& p)
         {
             // TODO
             //printLine(Print::Verbose, level * 2, "[key.spotlight]");
+            MANGO_UNREFERENCED(p);
         }
 
         void chunk_key_segment(LittleEndianConstPointer& p)

--- a/source/mango/import3d/import_gltf.cpp
+++ b/source/mango/import3d/import_gltf.cpp
@@ -47,7 +47,7 @@ ImportGLTF::ImportGLTF(const filesystem::Path& path, const std::string& filename
 
     filesystem::File file(path, filename);
 
-    fastgltf::GltfDataBuffer data = *fastgltf::GltfDataBuffer::FromBytes(
+    fastgltf::GltfDataBuffer dataBuffer = *fastgltf::GltfDataBuffer::FromBytes(
         reinterpret_cast<const std::byte*>(file.data()), file.size());
         
     // --------------------------------------------------------------------------
@@ -79,7 +79,7 @@ ImportGLTF::ImportGLTF(const filesystem::Path& path, const std::string& filename
 
     fastgltf::Parser parser(extensions);
 
-    auto type = fastgltf::determineGltfFileType(data);
+    auto type = fastgltf::determineGltfFileType(dataBuffer);
     switch (type)
     {
         case fastgltf::GltfType::glTF:
@@ -103,7 +103,7 @@ ImportGLTF::ImportGLTF(const filesystem::Path& path, const std::string& filename
     //options |= fastgltf::Options::LoadExternalImages;
     //options |= fastgltf::Options::LoadExternalImages;
 
-    auto expected_asset = parser.loadGltf(data, "", options);
+    auto expected_asset = parser.loadGltf(dataBuffer, "", options);
     if (expected_asset.error() != fastgltf::Error::None)
     {
         printLine(Print::Error, "  ERROR: {}", fastgltf::getErrorMessage(expected_asset.error()).data());
@@ -128,6 +128,7 @@ ImportGLTF::ImportGLTF(const filesystem::Path& path, const std::string& filename
             [] (const auto& arg)
             {
                 printLine(Print::Verbose, "  Unknown");
+                MANGO_UNREFERENCED(arg);
             },
             [&] (const fastgltf::sources::URI& source)
             {
@@ -160,6 +161,7 @@ ImportGLTF::ImportGLTF(const filesystem::Path& path, const std::string& filename
                 // [ ] binary
                 // [ ] embedded
                 printLine(Print::Verbose, "  BufferView:");
+                MANGO_UNREFERENCED(source);
             },
             [&](const fastgltf::sources::Array& array)
             {
@@ -205,6 +207,7 @@ ImportGLTF::ImportGLTF(const filesystem::Path& path, const std::string& filename
         {
             [] (const auto& arg)
             {
+                MANGO_UNREFERENCED(arg);
             },
             [&] (const fastgltf::sources::URI& source)
             {
@@ -263,6 +266,7 @@ ImportGLTF::ImportGLTF(const filesystem::Path& path, const std::string& filename
                 {
                     [] (auto& arg)
                     {
+                        MANGO_UNREFERENCED(arg);
                     },
                     [&](fastgltf::sources::Array& vector)
                     {
@@ -285,6 +289,7 @@ ImportGLTF::ImportGLTF(const filesystem::Path& path, const std::string& filename
             [&] (const fastgltf::sources::CustomBuffer& source)
             {
                 printLine(Print::Verbose, "  CustomBuffer: TODO");
+                MANGO_UNREFERENCED(source);
             },
         }, current.data);
 
@@ -887,20 +892,20 @@ ImportGLTF::ImportGLTF(const filesystem::Path& path, const std::string& filename
                         continue;
                 }
 
-                u64 time0 = Time::us();
+                u64 b_time0 = Time::us();
 
                 if (needTangent)
                 {
                     trimesh.computeTangents();
                 }
 
-                u64 time1 = Time::us();
+                u64 b_time1 = Time::us();
 
                 mesh.append(trimesh, u32(materialIndex));
 
-                u64 time2 = Time::us();
-                u64 delta0 = time1 - time0;
-                u64 delta1 = time2 - time1;
+                u64 b_time2 = Time::us();
+                u64 delta0 = b_time1 - b_time0;
+                u64 delta1 = b_time2 - b_time1;
 
                 printLine(Print::Verbose, "    Computing tangents: {}.{} ms", delta0 / 1000, delta0 % 1000);
                 printLine(Print::Verbose, "    Mesh Indexing: {}.{} ms", delta1 / 1000, delta1 % 1000);

--- a/source/mango/import3d/import_lwo.cpp
+++ b/source/mango/import3d/import_lwo.cpp
@@ -21,6 +21,8 @@ namespace
     static
     void xyz_to_h(float x, float y, float z, float& h)
     {
+        MANGO_UNREFERENCED(y);
+
         if (x == 0.0f && z == 0.0f)
         {
             h = 0.0f;

--- a/source/mango/import3d/import_obj.cpp
+++ b/source/mango/import3d/import_obj.cpp
@@ -194,12 +194,12 @@ namespace mango::import3d
                 u32 d = u32(*s) - '0';
                 if (d > 9)
                 {
-                    return result;
+                    // return result
+                    break;
                 }
                 result = result * 10 + d;
             }
 
-            //  unreachable
             return result;
         }
 
@@ -578,6 +578,8 @@ namespace mango::import3d
 
     void ReaderOBJ::parse_s(const std::string_view* tokens, size_t count)
     {
+        MANGO_UNREFERENCED(tokens);
+
         if (count != 1)
         {
             // error

--- a/source/mango/import3d/mesh.cpp
+++ b/source/mango/import3d/mesh.cpp
@@ -573,8 +573,8 @@ namespace mango::import3d
         params.scale *= 0.5f;
         params.thickness *= params.scale;
 
-        const float uscale = params.uscale / params.facets;
-        const float vscale = params.vscale / params.steps;
+        const float uscale = params.uscale / float(params.facets);
+        const float vscale = params.vscale / float(params.steps);
 
         auto ptr = std::make_unique<IndexedMesh>();
         IndexedMesh& mesh = *ptr;

--- a/source/mango/jpeg/jpeg.hpp
+++ b/source/mango/jpeg/jpeg.hpp
@@ -358,7 +358,7 @@ namespace mango::image::jpeg
     class Parser
     {
     protected:
-        ConstMemory memory;
+        ConstMemory m_memory;
         ImageDecodeInterface* m_interface;
         QuantTable quantTable[JPEG_MAX_COMPS_IN_SCAN];
 
@@ -390,13 +390,13 @@ namespace mango::image::jpeg
         const Surface* m_surface = nullptr; // temporary color conversion/clipping surface
         bool m_request_blitting = false;
 
-        int aligned_width;
-        int aligned_height;
-        int width;
-        int height;
+        int m_aligned_width;
+        int m_aligned_height;
+        int m_width;
+        int m_height;
 
-        int precision; // 8 or 12 bits
-        int components; // 1..4
+        int m_precision; // 8 or 12 bits
+        int m_components; // 1..4
 
         bool is_baseline = true;
         bool is_progressive = false;

--- a/source/mango/jpeg/jpeg.hpp
+++ b/source/mango/jpeg/jpeg.hpp
@@ -359,7 +359,7 @@ namespace mango::image::jpeg
     {
     protected:
         ConstMemory m_memory;
-        ImageDecodeInterface* m_interface;
+        ImageDecodeInterface* m_interface = nullptr;
         QuantTable quantTable[JPEG_MAX_COMPS_IN_SCAN];
 
         AlignedStorage<s16> quantTableVector;
@@ -464,8 +464,10 @@ namespace mango::image::jpeg
         ConstMemory scan_memory; // Scan block
         Buffer icc_buffer; // ICC color profile block, if one is present
 
-        Parser(ConstMemory memory, ImageDecodeInterface* interface);
+        Parser(ConstMemory memory);
         ~Parser();
+
+        void setInterface(ImageDecodeInterface* interface);
 
         ImageDecodeStatus decode(const Surface& target, const ImageDecodeOptions& options);
     };

--- a/source/mango/jpeg/jpeg_decode.cpp
+++ b/source/mango/jpeg/jpeg_decode.cpp
@@ -129,9 +129,8 @@ namespace mango::image::jpeg
     // Parser
     // ----------------------------------------------------------------------------
 
-    Parser::Parser(ConstMemory memory, ImageDecodeInterface* interface)
+    Parser::Parser(ConstMemory memory)
         : m_memory(memory)
-        , m_interface(interface)
         , quantTableVector(64 * JPEG_MAX_COMPS_IN_SCAN)
     {
         restartInterval = 0;
@@ -156,6 +155,11 @@ namespace mango::image::jpeg
 
     Parser::~Parser()
     {
+    }
+
+    void Parser::setInterface(ImageDecodeInterface* interface)
+    {
+        m_interface = interface;
     }
 
     bool Parser::isJPEG(ConstMemory memory) const

--- a/source/mango/jpeg/jpeg_decode.cpp
+++ b/source/mango/jpeg/jpeg_decode.cpp
@@ -130,7 +130,7 @@ namespace mango::image::jpeg
     // ----------------------------------------------------------------------------
 
     Parser::Parser(ConstMemory memory, ImageDecodeInterface* interface)
-        : memory(memory)
+        : m_memory(memory)
         , m_interface(interface)
         , quantTableVector(64 * JPEG_MAX_COMPS_IN_SCAN)
     {
@@ -144,9 +144,9 @@ namespace mango::image::jpeg
 
         m_surface = nullptr;
 
-        if (isJPEG(memory))
+        if (isJPEG(m_memory))
         {
-            parse(memory, false);
+            parse(m_memory, false);
         }
         else
         {
@@ -448,33 +448,33 @@ namespace mango::image::jpeg
         is_differential = false;
 
         u16 length = bigEndian::uload16(p + 0);
-        precision = p[2];
-        height = bigEndian::uload16(p + 3);
-        width  = bigEndian::uload16(p + 5);
-        components = p[7];
+        m_precision = p[2];
+        m_height = bigEndian::uload16(p + 3);
+        m_width  = bigEndian::uload16(p + 5);
+        m_components = p[7];
         p += 8;
 
-        printLine(Print::Info, "  Image: {} x {} x {}", width, height, precision);
+        printLine(Print::Info, "  Image: {} x {} x {}", m_width, m_height, m_precision);
 
-        u16 correct_length = 8 + 3 * components;
+        u16 correct_length = 8 + 3 * m_components;
         if (length != correct_length)
         {
             header.setError("Incorrect chunk length ({}, should be {}).", length, correct_length);
             return;
         }
 
-        if (width <= 0 || height <= 0 || width > 65535 || height > 65535)
+        if (m_width <= 0 || m_height <= 0 || m_width > 65535 || m_height > 65535)
         {
             // NOTE: ysize of 0 is allowed in the specs but we won't
-            header.setError("Incorrect dimensions ({} x {})", width, height);
+            header.setError("Incorrect dimensions ({} x {})", m_width, m_height);
             return;
         }
 
-        if (components < 1 || components > 4)
+        if (m_components < 1 || m_components > 4)
         {
             // NOTE: only progressive is required to have 1..4 components,
             //       other modes allow 1..255 but we are extra strict here :)
-            header.setError("Incorrect number of components ({})", components);
+            header.setError("Incorrect number of components ({})", m_components);
             return;
         }
 
@@ -519,7 +519,7 @@ namespace mango::image::jpeg
             case MARKER_SOF7:
             case MARKER_SOF15:
                 is_differential = true;
-                // fall-through
+                [[fallthrough]];
             case MARKER_SOF3:
             case MARKER_SOF11:
                 is_lossless = true;
@@ -528,25 +528,25 @@ namespace mango::image::jpeg
 
         if (is_baseline)
         {
-            if (precision != 8)
+            if (m_precision != 8)
             {
-                header.setError("Incorrect precision ({}, allowed: 8)", precision);
+                header.setError("Incorrect precision ({}, allowed: 8)", m_precision);
                 return;
             }
         }
         else if (is_lossless)
         {
-            if (precision < 2 || precision > 16)
+            if (m_precision < 2 || m_precision > 16)
             {
-                header.setError("Incorrect precision ({}, allowed: 2..16)", precision);
+                header.setError("Incorrect precision ({}, allowed: 2..16)", m_precision);
                 return;
             }
         }
         else
         {
-            if (precision != 8 && precision != 12)
+            if (m_precision != 8 && m_precision != 12)
             {
-                header.setError("Incorrect precision ({}, allowed: 8, 12)", precision);
+                header.setError("Incorrect precision ({}, allowed: 8, 12)", m_precision);
                 return;
             }
         }
@@ -556,9 +556,9 @@ namespace mango::image::jpeg
         blocks_in_mcu = 0;
         int offset = 0;
 
-        processState.frames = components;
+        processState.frames = m_components;
 
-        for (int i = 0; i < components; ++i)
+        for (int i = 0; i < m_components; ++i)
         {
             if (offset >= JPEG_MAX_BLOCKS_IN_MCU)
             {
@@ -569,9 +569,9 @@ namespace mango::image::jpeg
             Frame& frame = processState.frame[i];
 
             frame.compid = p[0];
-            u8 x = p[1];
-            frame.hsf = (x >> 4) & 0xf;
-            frame.vsf = (x >> 0) & 0xf;
+            u8 hv = p[1];
+            frame.hsf = (hv >> 4) & 0xf;
+            frame.vsf = (hv >> 0) & 0xf;
             frame.tq = p[2];
             frame.offset = offset;
             p += 3;
@@ -583,7 +583,7 @@ namespace mango::image::jpeg
                 return;
             }
 
-            if (components == 1)
+            if (m_components == 1)
             {
                 // Optimization: force block size to 8x8 with grayscale images
                 frame.hsf = 1;
@@ -644,22 +644,22 @@ namespace mango::image::jpeg
         // Align to next MCU boundary
         int xmask = xblock - 1;
         int ymask = yblock - 1;
-        aligned_width  = (width  + xmask) & ~xmask;
-        aligned_height = (height + ymask) & ~ymask;
+        m_aligned_width  = (m_width  + xmask) & ~xmask;
+        m_aligned_height = (m_height + ymask) & ~ymask;
 
         // MCU resolution
-        xmcu = aligned_width  / xblock;
-        ymcu = aligned_height / yblock;
+        xmcu = m_aligned_width  / xblock;
+        ymcu = m_aligned_height / yblock;
         mcus = xmcu * ymcu;
 
         printLine(Print::Info, "  {} MCUs ({} x {}) -> ({} x {})", mcus, xmcu, ymcu, xmcu * xblock, ymcu * yblock);
-        printLine(Print::Info, "  Image: {} x {}", width, height);
+        printLine(Print::Info, "  Image: {} x {}", m_width, m_height);
 
         // configure header
-        header.width  = width;
-        header.height = height;
-        header.format = components > 1 ? Format(32, Format::UNORM, Format::RGBA, 8, 8, 8, 8)
-                                       : LuminanceFormat(8, Format::UNORM, 8, 0);
+        header.width  = m_width;
+        header.height = m_height;
+        header.format = m_components > 1 ? Format(32, Format::UNORM, Format::RGBA, 8, 8, 8, 8)
+                                         : LuminanceFormat(8, Format::UNORM, 8, 0);
 
         MANGO_UNREFERENCED(length);
     }
@@ -1474,7 +1474,7 @@ namespace mango::image::jpeg
         }
 #endif
 
-        if (precision == 12)
+        if (m_precision == 12)
         {
             // Force 12 bit idct
             // This will round down to 8 bit precision until we have a 12 bit capable color conversion
@@ -1696,7 +1696,7 @@ namespace mango::image::jpeg
         std::string id;
 
         // determine jpeg type -> select innerloops
-        switch (components)
+        switch (m_components)
         {
             case 1:
                 processState.process = process_y;
@@ -1791,7 +1791,7 @@ namespace mango::image::jpeg
         if (is_lossless)
         {
             // lossless only supports L8 and RGBA
-            if (components == 1)
+            if (m_components == 1)
             {
                 sf.sample = JPEG_U8_Y;
                 sf.format = LuminanceFormat(8, Format::UNORM, 8, 0);
@@ -1802,7 +1802,7 @@ namespace mango::image::jpeg
                 sf.format = Format(32, Format::UNORM, Format::RGBA, 8, 8, 8, 8);
             }
         }
-        else if (components == 4)
+        else if (m_components == 4)
         {
             // CMYK / YCCK is in the slow-path anyway so force RGBA
             sf.sample = JPEG_U8_RGBA;
@@ -1811,7 +1811,7 @@ namespace mango::image::jpeg
 
         m_decode_status.direct = true;
 
-        if (target.width < width || target.height < height)
+        if (target.width < m_width || target.height < m_height)
         {
             m_decode_status.direct = false;
         }
@@ -1831,7 +1831,7 @@ namespace mango::image::jpeg
         if (!m_decode_status.direct)
         {
             // create a temporary decoding target
-            temp = std::make_unique<Bitmap>(aligned_width, aligned_height, sf.format);
+            temp = std::make_unique<Bitmap>(m_aligned_width, m_aligned_height, sf.format);
             m_surface = temp.get();
         }
 
@@ -1863,8 +1863,8 @@ namespace mango::image::jpeg
 
             rect.x = 0;
             rect.y = 0;
-            rect.width = width;
-            rect.height = height;
+            rect.width = m_width;
+            rect.height = m_height;
             rect.progress = 1.0f;
 
             blit_and_update(rect, true);
@@ -1929,23 +1929,23 @@ namespace mango::image::jpeg
             previousDC = decodeState.arithmetic.last_dc_value;
         }
 
-        const int width  = m_surface->width;
-        const int height = m_surface->height;
-        const int xlast = width - 1;
-        const int components = decodeState.comps_in_scan;
+        const int xsize = m_surface->width;
+        const int ysize = m_surface->height;
+        const int xlast = xsize - 1;
+        const int n_components = decodeState.comps_in_scan;
 
-        int initPredictor = 1 << (precision - pointTransform - 1);
+        int initPredictor = 1 << (m_precision - pointTransform - 1);
 
         std::vector<int> scanLineCache[JPEG_MAX_BLOCKS_IN_MCU];
 
-        for (int i = 0; i < components; ++i)
+        for (int i = 0; i < n_components; ++i)
         {
-            scanLineCache[i] = std::vector<int>(width + 1, 0);
+            scanLineCache[i] = std::vector<int>(xsize + 1, 0);
         }
 
         bool first = true;
 
-        for (int y = 0; y < height; ++y)
+        for (int y = 0; y < ysize; ++y)
         {
             if (m_interface->cancelled)
             {
@@ -1954,7 +1954,7 @@ namespace mango::image::jpeg
 
             u8* image = m_surface->address<u8>(0, y);
 
-            for (int x = 0; x < width; ++x)
+            for (int x = 0; x < xsize; ++x)
             {
                 s16 data[JPEG_MAX_BLOCKS_IN_MCU];
 
@@ -1963,7 +1963,7 @@ namespace mango::image::jpeg
                 bool init = restarted | first;
                 first = false;
 
-                for (int currentComponent = 0; currentComponent < components; ++currentComponent)
+                for (int currentComponent = 0; currentComponent < n_components; ++currentComponent)
                 {
                     // predictors
                     int* cache = scanLineCache[currentComponent].data();
@@ -1999,19 +1999,19 @@ namespace mango::image::jpeg
                     previousDC[currentComponent] = s;
 
                     cache[x] = data[currentComponent];
-                    data[currentComponent] = data[currentComponent] >> (precision - 8);
+                    data[currentComponent] = data[currentComponent] >> (m_precision - 8);
                 }
 
-                if (components == 1)
+                if (n_components == 1)
                 {
-                    image[0] = byteclamp(data[0] + 128);
+                    image[0] = u8_clamp(data[0] + 128);
                     image += 1;
                 }
                 else
                 {
-                    image[0] = byteclamp(data[0] + 128); // red
-                    image[1] = byteclamp(data[1] + 128); // green
-                    image[2] = byteclamp(data[2] + 128); // blue
+                    image[0] = u8_clamp(data[0] + 128); // red
+                    image[1] = u8_clamp(data[1] + 128); // green
+                    image[2] = u8_clamp(data[2] + 128); // blue
                     image[3] = 0xff;
                     image += 4;
                 }
@@ -2067,8 +2067,8 @@ namespace mango::image::jpeg
                     const int xmcu_last = xmcu - 1;
                     const int ymcu_last = ymcu - 1;
 
-                    const int xclip = width  % xblock;
-                    const int yclip = height % yblock;
+                    const int xclip = m_width  % xblock;
+                    const int yclip = m_height % yblock;
                     const int xblock_last = xclip ? xclip : xblock;
                     const int yblock_last = yclip ? yclip : yblock;
 
@@ -2078,10 +2078,10 @@ namespace mango::image::jpeg
                     {
                         decodeState.decode(data, &decodeState);
 
-                        int width  = x == xmcu_last ? xblock_last : xblock;
-                        int height = y == ymcu_last ? yblock_last : yblock;
+                        int xsize = x == xmcu_last ? xblock_last : xblock;
+                        int ysize = y == ymcu_last ? yblock_last : yblock;
 
-                        process_and_clip(dest, stride, data, width, height);
+                        process_and_clip(dest, stride, data, xsize, ysize);
                         dest += xstride;
 
                         if (++restart_counter == restartInterval)
@@ -2111,9 +2111,9 @@ namespace mango::image::jpeg
 
                 rect.x = 0;
                 rect.y = y0 * yblock;
-                rect.width = width;
-                rect.height = std::min(height, y1 * yblock) - y0 * yblock;
-                rect.progress = float(rect.height) / height;
+                rect.width = m_width;
+                rect.height = std::min(m_height, y1 * yblock) - y0 * yblock;
+                rect.progress = float(rect.height) / m_height;
 
                 blit_and_update(rect);
             }
@@ -2206,8 +2206,8 @@ namespace mango::image::jpeg
 
                     const int xmcu_last = xmcu - 1;
                     const int ymcu_last = ymcu - 1;
-                    const int xclip = width  % xblock;
-                    const int yclip = height % yblock;
+                    const int xclip = m_width  % xblock;
+                    const int yclip = m_height % yblock;
                     const int xblock_last = xclip ? xclip : xblock;
                     const int yblock_last = yclip ? yclip : yblock;
 
@@ -2222,7 +2222,7 @@ namespace mango::image::jpeg
 
                         DecodeState state = decodeState;
                         state.buffer.ptr = ptr;
-                        ptr = memory.address + offsets[i];
+                        ptr = m_memory.address + offsets[i];
 
                         u8* dest = image + i * ystride;
                         int height = (i == ymcu_last) ? yblock_last : yblock;
@@ -2243,15 +2243,15 @@ namespace mango::image::jpeg
 
                     rect.x = 0;
                     rect.y = y0 * yblock;
-                    rect.width = width;
-                    rect.height = std::min(height, y1 * yblock) - y0 * yblock;
-                    rect.progress = float(rect.height) / height;
+                    rect.width = m_width;
+                    rect.height = std::min(m_height, y1 * yblock) - y0 * yblock;
+                    rect.progress = float(rect.height) / m_height;
 
                     blit_and_update(rect);
                 });
 
                 // use last offset in the range
-                p = memory.address + offsets[y1 - 1];
+                p = m_memory.address + offsets[y1 - 1];
             }
 
             // update parser pointer
@@ -2310,8 +2310,8 @@ namespace mango::image::jpeg
                         const int xmcu_last = xmcu - 1;
                         const int ymcu_last = ymcu - 1;
 
-                        const int xclip = width  % xblock;
-                        const int yclip = height % yblock;
+                        const int xclip = m_width  % xblock;
+                        const int yclip = m_height % yblock;
                         const int xblock_last = xclip ? xclip : xblock;
                         const int yblock_last = yclip ? yclip : yblock;
 
@@ -2344,9 +2344,9 @@ namespace mango::image::jpeg
 
                     rect.x = 0;
                     rect.y = y0 * yblock;
-                    rect.width = width;
-                    rect.height = std::min(height, y1 * yblock) - y0 * yblock;
-                    rect.progress = float(rect.height) / height;
+                    rect.width = m_width;
+                    rect.height = std::min(m_height, y1 * yblock) - y0 * yblock;
+                    rect.progress = float(rect.height) / m_height;
 
                     blit_and_update(rect);
                 }, p);
@@ -2541,8 +2541,8 @@ namespace mango::image::jpeg
             printLine(Print::Info, "    hsf: {}, vsf: {}, blocks: {}", hsf, vsf, decodeState.blocks);
 
             const int scan_offset = scanFrame->offset;
-            const int xs = div_ceil(width, hsize);
-            const int ys = div_ceil(height, vsize);
+            const int xs = div_ceil(m_width, hsize);
+            const int ys = div_ceil(m_height, vsize);
             const int cnt = xs * ys;
 
             printLine(Print::Info, "    blocks: {} x {} ({} x {})", xs, ys, xs * hsize, ys * vsize);
@@ -2609,8 +2609,8 @@ namespace mango::image::jpeg
             printLine(Print::Info, "    hsf: {}, vsf: {}, blocks: {}", hsf, vsf, decodeState.blocks);
 
             const int scan_offset = scanFrame->offset;
-            const int xs = div_ceil(width, hsize);
-            const int ys = div_ceil(height, vsize);
+            const int xs = div_ceil(m_width, hsize);
+            const int ys = div_ceil(m_height, vsize);
 
             printLine(Print::Info, "    blocks: {} x {} ({} x {})", xs, ys, xs * hsize, ys * vsize);
 
@@ -2688,8 +2688,8 @@ namespace mango::image::jpeg
         const int xmcu_last = xmcu - 1;
         const int ymcu_last = ymcu - 1;
 
-        const int xclip = width  % xblock;
-        const int yclip = height % yblock;
+        const int xclip = m_width  % xblock;
+        const int yclip = m_height % yblock;
         const int xblock_last = xclip ? xclip : xblock;
         const int yblock_last = yclip ? yclip : yblock;
 
@@ -2701,17 +2701,17 @@ namespace mango::image::jpeg
             }
 
             u8* dest = image + y * ystride;
-            int height = y == ymcu_last ? yblock_last : yblock;
+            int ysize = y == ymcu_last ? yblock_last : yblock;
 
             for (int x = 0; x < xmcu_last; ++x)
             {
-                process_and_clip(dest, stride, data, xblock, height);
+                process_and_clip(dest, stride, data, xblock, ysize);
                 data += mcu_data_size;
                 dest += xstride;
             }
 
             // last column
-            process_and_clip(dest, stride, data, xblock_last, height);
+            process_and_clip(dest, stride, data, xblock_last, ysize);
             data += mcu_data_size;
             dest += xstride;
         }
@@ -2720,9 +2720,9 @@ namespace mango::image::jpeg
 
         rect.x = 0;
         rect.y = y0 * yblock;
-        rect.width = width;
-        rect.height = std::min(height, y1 * yblock) - y0 * yblock;
-        rect.progress = float(rect.height) / height;
+        rect.width = m_width;
+        rect.height = std::min(m_height, y1 * yblock) - y0 * yblock;
+        rect.progress = float(rect.height) / m_height;
 
         blit_and_update(rect);
     }

--- a/source/mango/jpeg/jpeg_decode.cpp
+++ b/source/mango/jpeg/jpeg_decode.cpp
@@ -142,15 +142,6 @@ namespace mango::image::jpeg
         }
 
         m_surface = nullptr;
-
-        if (isJPEG(m_memory))
-        {
-            parse(m_memory, false);
-        }
-        else
-        {
-            header.setError("Incorrect SOI marker.");
-        }
     }
 
     Parser::~Parser()
@@ -160,6 +151,15 @@ namespace mango::image::jpeg
     void Parser::setInterface(ImageDecodeInterface* interface)
     {
         m_interface = interface;
+
+        if (isJPEG(m_memory))
+        {
+            parse(m_memory, false);
+        }
+        else
+        {
+            header.setError("Incorrect SOI marker.");
+        }
     }
 
     bool Parser::isJPEG(ConstMemory memory) const

--- a/source/mango/jpeg/jpeg_encode.cpp
+++ b/source/mango/jpeg/jpeg_encode.cpp
@@ -203,8 +203,8 @@ namespace
         code = byteswap(code);
         for (int i = 0; i < count; ++i)
         {
-            u32 value = code & 0xff;
-            u32 is_stuff_byte = value == 0xff;
+            u8 value = u8(code & 0xff);
+            u8 is_stuff_byte = value == 0xff;
             code >>= 8;
             output[0] = value;
             output[1] = 0;

--- a/source/mango/jpeg/jpeg_idct.cpp
+++ b/source/mango/jpeg/jpeg_idct.cpp
@@ -106,14 +106,14 @@ namespace
             idct.x1 += bias;
             idct.x2 += bias;
             idct.x3 += bias;
-            dest[0] = byteclamp((idct.x0 + idct.y3) >> shift);
-            dest[1] = byteclamp((idct.x1 + idct.y2) >> shift);
-            dest[2] = byteclamp((idct.x2 + idct.y1) >> shift);
-            dest[3] = byteclamp((idct.x3 + idct.y0) >> shift);
-            dest[4] = byteclamp((idct.x3 - idct.y0) >> shift);
-            dest[5] = byteclamp((idct.x2 - idct.y1) >> shift);
-            dest[6] = byteclamp((idct.x1 - idct.y2) >> shift);
-            dest[7] = byteclamp((idct.x0 - idct.y3) >> shift);
+            dest[0] = u8_clamp((idct.x0 + idct.y3) >> shift);
+            dest[1] = u8_clamp((idct.x1 + idct.y2) >> shift);
+            dest[2] = u8_clamp((idct.x2 + idct.y1) >> shift);
+            dest[3] = u8_clamp((idct.x3 + idct.y0) >> shift);
+            dest[4] = u8_clamp((idct.x3 - idct.y0) >> shift);
+            dest[5] = u8_clamp((idct.x2 - idct.y1) >> shift);
+            dest[6] = u8_clamp((idct.x1 - idct.y2) >> shift);
+            dest[7] = u8_clamp((idct.x0 - idct.y3) >> shift);
             dest += 8;
         }
     }

--- a/source/mango/jpeg/jpeg_process.cpp
+++ b/source/mango/jpeg/jpeg_process.cpp
@@ -118,7 +118,7 @@ void process_cmyk_rgba(u8* dest, size_t stride, const s16* data, ProcessState* s
             for (int xblock = 0; xblock < hsf; ++xblock)
             {
                 u8* source = result + offset + (yblock * hsf + xblock) * 64;
-                u8* dest = temp + channel * JPEG_MAX_SAMPLES_IN_MCU + yblock * 8 * (hmax * 8) + xblock * 8;
+                u8* d = temp + channel * JPEG_MAX_SAMPLES_IN_MCU + yblock * 8 * (hmax * 8) + xblock * 8;
 
                 if (hmax != hsf || vmax != vsf)
                 {
@@ -130,15 +130,15 @@ void process_cmyk_rgba(u8* dest, size_t stride, const s16* data, ProcessState* s
                         for (int x = 0; x < 8; ++x)
                         {
                             u8 sample = *source++;
-                            std::memset(dest + x * xscale, sample, xscale);
+                            std::memset(d + x * xscale, sample, xscale);
                         }
 
-                        dest += hmax * 8;
+                        d += hmax * 8;
 
                         for (int s = 1; s < yscale; ++s)
                         {
-                            std::memcpy(dest, dest - hmax * 8, xscale * 8);
-                            dest += hmax * 8;
+                            std::memcpy(d, d - hmax * 8, xscale * 8);
+                            d += hmax * 8;
                         }
                     }
                 }
@@ -146,9 +146,9 @@ void process_cmyk_rgba(u8* dest, size_t stride, const s16* data, ProcessState* s
                 {
                     for (int y = 0; y < 8; ++y)
                     {
-                        std::memcpy(dest, source, 8);
+                        std::memcpy(d, source, 8);
                         source += 8;
-                        dest += hmax * 8;
+                        d += hmax * 8;
                     }
                 }
             }
@@ -258,35 +258,35 @@ void process_ycbcr_8bit(u8* dest, size_t stride, const s16* data, ProcessState* 
 static inline
 void write_color_bgra(u8* dest, int y, int r, int g, int b)
 {
-    dest[0] = byteclamp(b + y);
-    dest[1] = byteclamp(g + y);
-    dest[2] = byteclamp(r + y);
+    dest[0] = u8_clamp(b + y);
+    dest[1] = u8_clamp(g + y);
+    dest[2] = u8_clamp(r + y);
     dest[3] = 0xff;
 }
 
 static inline
 void write_color_rgba(u8* dest, int y, int r, int g, int b)
 {
-    dest[0] = byteclamp(r + y);
-    dest[1] = byteclamp(g + y);
-    dest[2] = byteclamp(b + y);
+    dest[0] = u8_clamp(r + y);
+    dest[1] = u8_clamp(g + y);
+    dest[2] = u8_clamp(b + y);
     dest[3] = 0xff;
 }
 
 static inline
 void write_color_bgr(u8* dest, int y, int r, int g, int b)
 {
-    dest[0] = byteclamp(b + y);
-    dest[1] = byteclamp(g + y);
-    dest[2] = byteclamp(r + y);
+    dest[0] = u8_clamp(b + y);
+    dest[1] = u8_clamp(g + y);
+    dest[2] = u8_clamp(r + y);
 }
 
 static inline
 void write_color_rgb(u8* dest, int y, int r, int g, int b)
 {
-    dest[0] = byteclamp(r + y);
-    dest[1] = byteclamp(g + y);
-    dest[2] = byteclamp(b + y);
+    dest[0] = u8_clamp(r + y);
+    dest[1] = u8_clamp(g + y);
+    dest[2] = u8_clamp(b + y);
 }
 
 // Generate YCBCR to BGRA functions
@@ -515,8 +515,8 @@ void convert_ycbcr_rgb_8x1_neon(u8* dest, int16x8_t y, int16x8_t cb, int16x8_t c
 // [License]
 // Public Domain <unlicense.org>
 
-static constexpr int JPEG_PREC = 12;
-static constexpr int JPEG_FIXED(double x) { return int((x * double(1 << JPEG_PREC) + 0.5)); }
+static constexpr s16 JPEG_PREC = 12;
+static constexpr s16 JPEG_FIXED(double x) { return s16((x * double(1 << JPEG_PREC) + 0.5)); }
 
 #define JPEG_CONST_SSE2(x, y)  _mm_setr_epi16(x, y, x, y, x, y, x, y)
 

--- a/source/mango/jpeg/jpeg_process_func.hpp
+++ b/source/mango/jpeg/jpeg_process_func.hpp
@@ -34,7 +34,7 @@ void FUNCTION_GENERIC(u8* dest, size_t stride, const s16* data, ProcessState* st
             for (int xblock = 0; xblock < hsf; ++xblock)
             {
                 u8* source = result + offset + (yblock * hsf + xblock) * 64;
-                u8* dest = temp + channel * JPEG_MAX_SAMPLES_IN_MCU + yblock * 8 * (hmax * 8) + xblock * 8;
+                u8* d = temp + channel * JPEG_MAX_SAMPLES_IN_MCU + yblock * 8 * (hmax * 8) + xblock * 8;
 
                 if (hmax != hsf || vmax != vsf)
                 {
@@ -46,15 +46,15 @@ void FUNCTION_GENERIC(u8* dest, size_t stride, const s16* data, ProcessState* st
                         for (int x = 0; x < 8; ++x)
                         {
                             u8 sample = *source++;
-                            std::memset(dest + x * xscale, sample, xscale);
+                            std::memset(d + x * xscale, sample, xscale);
                         }
 
-                        dest += hmax * 8;
+                        d += hmax * 8;
 
                         for (int s = 1; s < yscale; ++s)
                         {
-                            std::memcpy(dest, dest - hmax * 8, xscale * 8);
-                            dest += hmax * 8;
+                            std::memcpy(d, d - hmax * 8, xscale * 8);
+                            d += hmax * 8;
                         }
                     }
                 }
@@ -62,9 +62,9 @@ void FUNCTION_GENERIC(u8* dest, size_t stride, const s16* data, ProcessState* st
                 {
                     for (int y = 0; y < 8; ++y)
                     {
-                        std::memcpy(dest, source, 8);
+                        std::memcpy(d, source, 8);
                         source += 8;
-                        dest += hmax * 8;
+                        d += hmax * 8;
                     }
                 }
             }

--- a/source/mango/opengl/framebuffer.cpp
+++ b/source/mango/opengl/framebuffer.cpp
@@ -442,7 +442,7 @@ namespace mango
 
             glUniform1i(p.texture, 0);
             glUniform4f(p.transform, translate.x, -translate.y, scale.x, scale.y);
-            glUniform2f(p.scale, 1.0f / m_width, 1.0f / m_height);
+            glUniform2f(p.scale, 1.0f / float(m_width), 1.0f / float(m_height));
 
             if (p.position != -1)
             {

--- a/source/mango/window/win32/win32_window.cpp
+++ b/source/mango/window/win32/win32_window.cpp
@@ -290,6 +290,7 @@ namespace
 
         ::EnumDisplayMonitors(NULL, NULL, [] (HMONITOR monitor, HDC hdc, LPRECT rect, LPARAM data) -> BOOL
         {
+            MANGO_UNREFERENCED(hdc);
             std::vector<ScreenInfo>& screens = *reinterpret_cast<std::vector<ScreenInfo>*>(data);
 
             int width = rect->right - rect->left;


### PR DESCRIPTION
Fix all warnings with /Wall on WIN32 build (in mango code).
Refactoring code was needed in some cases so that variables in parent scope aren't suppressed.
