### PR TITLE
Refactor JPEG decoding engine.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.19)
 project(mango
-        VERSION 3.5.6
+        VERSION 3.5.7
         DESCRIPTION "C++ Graphics Library for the NÖRDS"
         LANGUAGES CXX C)
 

--- a/source/mango/image/image_jpg.cpp
+++ b/source/mango/image/image_jpg.cpp
@@ -52,9 +52,14 @@ namespace
 
             ImageDecodeStatus status = m_parser.decode(dest, options);
 
-            if (m_parser.cmykIccApplied())
+            // Four-component JPEG output is always display-ready sRGB RGBA. Drop the
+            // embedded CMYK ICC so clients (imageview, ifap) do not run a generic RGBA
+            // ICC transform on top of the decoder's CMYK/YCCK handling.
+            if (status && m_parser.components() == 4)
             {
                 icc = ConstMemory();
+                header.color.primaries = ColorPrimaries::BT709;
+                header.color.transfer = TransferFunction::sRGB;
             }
 
             return status;

--- a/source/mango/jpeg/jpeg.hpp
+++ b/source/mango/jpeg/jpeg.hpp
@@ -688,6 +688,11 @@ namespace mango::image::jpeg
             return m_cmyk_icc_applied;
         }
 
+        int components() const
+        {
+            return m_components;
+        }
+
         ImageDecodeStatus decode(const Surface& target, const ImageDecodeOptions& options);
     };
 
@@ -756,6 +761,11 @@ namespace mango::image::jpeg
             return m_base.cmykIccApplied();
         }
 
+        int components() const
+        {
+            return m_base.components();
+        }
+
         ImageDecodeStatus decode(const Surface& target, const ImageDecodeOptions& options);
     };
 
@@ -790,7 +800,8 @@ namespace mango::image::jpeg
     JPEG_COLOR_KERNEL(process_cmyk_store_rgba);
 
     // CMYK scanlines stored as C,M,Y,K in RGBA byte slots; converts in-place to display sRGB.
-    bool transform_cmyk_surface_to_srgb(Surface& surface, ConstMemory icc);
+    // invert_adobe: true for raw CMYK JPEG (Adobe stores 0 = 100% ink); false after YCCK decode.
+    bool transform_cmyk_surface_to_srgb(Surface& surface, ConstMemory icc, bool invert_adobe = true);
     void simple_cmyk_surface_to_rgba(Surface& surface);
     JPEG_COLOR_KERNEL(process_ycbcr_8bit);
 

--- a/source/mango/jpeg/jpeg.hpp
+++ b/source/mango/jpeg/jpeg.hpp
@@ -134,6 +134,15 @@ namespace mango::image::jpeg
 
     static constexpr int JPEG_MAX_BLOCKS_IN_MCU  = 10;  // Maximum # of blocks per MCU in the JPEG specification
     static constexpr int JPEG_MAX_SAMPLES_IN_MCU = 64 * JPEG_MAX_BLOCKS_IN_MCU;
+
+    // Spatial decode tile: K MCU slots of chunky 8x8 blocks (64 contiguous samples each).
+    // Sized for L1, not a full scan row (a 16000-pixel image is 1000 16-pixel MCUs wide).
+    static constexpr int JPEG_MCU_TILE = 16;
+
+    #define JPEG_COLOR_CAT2(a, b) a##b
+    #define JPEG_COLOR_CAT(a, b) JPEG_COLOR_CAT2(a, b)
+    #define JPEG_COLOR_FUNC(name) JPEG_COLOR_CAT(name, _color)
+
     static constexpr int JPEG_MAX_COMPS_IN_SCAN  = 4;   // JPEG limit on # of components in one scan
     static constexpr int JPEG_NUM_ARITH_TBLS     = 16;  // Arith-coding tables are numbered 0..15
     static constexpr int JPEG_DC_STAT_BINS       = 64;  // ...
@@ -338,6 +347,11 @@ namespace mango::image::jpeg
         s16* qt;
     };
 
+    struct ProcessState;
+
+    using ProcessFunc = void (*)(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    using ColorFunc   = void (*)(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride);
+
     struct ProcessState
     {
         // NOTE: this is just quantization tables
@@ -349,8 +363,22 @@ namespace mango::image::jpeg
 
         ColorSpace colorspace = ColorSpace::CMYK; // default
 
+        // Byte offset in the per-MCU spatial slot for Huffman block i.
+        // Sequential (i * 64) except SIMD 16x16, which shuffles Y1/Y2 so color
+        // can load a vertical pair with a 32-byte stride (Y0@0, Y2@64, Y1@128, Y3@192).
+        int idct_offset[JPEG_MAX_BLOCKS_IN_MCU];
+
         void (*idct) (u8* dest, const s16* data, const s16* qt);
         void (*process) (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+        ColorFunc color = nullptr; // specialized kernels only; reads ready spatial samples
+
+        void idctMCU(u8* spatial, const s16* data) const
+        {
+            for (int i = 0; i < blocks; ++i)
+            {
+                idct(spatial + idct_offset[i], data + i * 64, block[i].qt);
+            }
+        }
     };
 
     // ----------------------------------------------------------------------------
@@ -544,6 +572,8 @@ namespace mango::image::jpeg
 
         void process_range(int y0, int y1, const s16* data);
         void process_and_clip(u8* dest, size_t stride, const s16* data, int width, int height);
+        void color_and_clip(u8* dest, size_t stride, const u8* spatial, int width, int height);
+        void process_span(u8* dest, size_t stride, const s16* data, int count, int width, int height);
         void blit_and_update(const ImageDecodeRect& rect);
 
         int getTaskSize(int count) const;
@@ -696,53 +726,57 @@ namespace mango::image::jpeg
     void process_rgb_bgra              (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
     void process_rgb_rgba              (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
 
+#define JPEG_YCBCR_KERNEL(name) \
+    void name(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height); \
+    void name##_color(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
+
     void process_ycbcr_bgr              (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgr_8x8          (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgr_8x16         (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgr_16x8         (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgr_16x16        (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgr_8x8);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgr_8x16);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgr_16x8);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgr_16x16);
 
     void process_ycbcr_rgb              (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgb_8x8          (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgb_8x16         (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgb_16x8         (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgb_16x16        (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgb_8x8);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgb_8x16);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgb_16x8);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgb_16x16);
 
     void process_ycbcr_bgra             (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgra_8x8         (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgra_8x16        (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgra_16x8        (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgra_16x16       (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgra_8x8);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgra_8x16);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgra_16x8);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgra_16x16);
 
     void process_ycbcr_rgba             (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgba_8x8         (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgba_8x16        (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgba_16x8        (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgba_16x16       (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgba_8x8);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgba_8x16);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgba_16x8);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgba_16x16);
 
 #if defined(MANGO_ENABLE_NEON)
 
     void idct_neon                      (u8* dest, const s16* data, const s16* qt);
 
-    void process_ycbcr_bgra_8x8_neon    (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgra_8x16_neon   (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgra_16x8_neon   (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgra_16x16_neon  (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgra_8x8_neon);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgra_8x16_neon);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgra_16x8_neon);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgra_16x16_neon);
 
-    void process_ycbcr_rgba_8x8_neon    (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgba_8x16_neon   (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgba_16x8_neon   (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgba_16x16_neon  (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgba_8x8_neon);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgba_8x16_neon);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgba_16x8_neon);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgba_16x16_neon);
 
-    void process_ycbcr_bgr_8x8_neon     (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgr_8x16_neon    (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgr_16x8_neon    (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgr_16x16_neon   (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgr_8x8_neon);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgr_8x16_neon);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgr_16x8_neon);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgr_16x16_neon);
 
-    void process_ycbcr_rgb_8x8_neon     (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgb_8x16_neon    (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgb_16x8_neon    (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgb_16x16_neon   (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgb_8x8_neon);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgb_8x16_neon);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgb_16x8_neon);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgb_16x16_neon);
 
 #endif // MANGO_ENABLE_NEON
 
@@ -750,37 +784,39 @@ namespace mango::image::jpeg
 
     void idct_sse2                      (u8* dest, const s16* data, const s16* qt);
 
-    void process_ycbcr_bgra_8x8_sse2    (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgra_8x16_sse2   (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgra_16x8_sse2   (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgra_16x16_sse2  (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgra_8x8_sse2);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgra_8x16_sse2);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgra_16x8_sse2);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgra_16x16_sse2);
 
-    void process_ycbcr_rgba_8x8_sse2    (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgba_8x16_sse2   (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgba_16x8_sse2   (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgba_16x16_sse2  (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgba_8x8_sse2);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgba_8x16_sse2);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgba_16x8_sse2);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgba_16x16_sse2);
 
 #endif // MANGO_ENABLE_SSE2
 
 #if defined(MANGO_ENABLE_SSE4_1)
 
-    void process_ycbcr_bgr_8x8_sse41    (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgr_8x16_sse41   (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgr_16x8_sse41   (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_bgr_16x16_sse41  (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgr_8x8_sse41);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgr_8x16_sse41);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgr_16x8_sse41);
+    JPEG_YCBCR_KERNEL(process_ycbcr_bgr_16x16_sse41);
 
-    void process_ycbcr_rgb_8x8_sse41    (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgb_8x16_sse41   (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgb_16x8_sse41   (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_ycbcr_rgb_16x16_sse41  (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgb_8x8_sse41);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgb_8x16_sse41);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgb_16x8_sse41);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgb_16x16_sse41);
 
 #endif // MANGO_ENABLE_SSE4_1
 
 #if defined(MANGO_ENABLE_AVX2)
 
-    void process_ycbcr_rgba_8x8_avx2    (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    JPEG_YCBCR_KERNEL(process_ycbcr_rgba_8x8_avx2);
 
 #endif // MANGO_ENABLE_AVX2
+
+#undef JPEG_YCBCR_KERNEL
 
     SampleFormat getSampleFormat(const Format& format);
     ImageEncodeStatus encodeImage(Stream& stream, const Surface& surface, const ImageEncodeOptions& options);

--- a/source/mango/jpeg/jpeg.hpp
+++ b/source/mango/jpeg/jpeg.hpp
@@ -349,8 +349,7 @@ namespace mango::image::jpeg
 
     struct ProcessState;
 
-    using ProcessFunc = void (*)(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    using ColorFunc   = void (*)(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride);
+    using ColorFunc = void (*)(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride);
 
     struct ProcessState
     {
@@ -369,8 +368,7 @@ namespace mango::image::jpeg
         int idct_offset[JPEG_MAX_BLOCKS_IN_MCU];
 
         void (*idct) (u8* dest, const s16* data, const s16* qt);
-        void (*process) (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-        ColorFunc color = nullptr; // specialized kernels only; reads ready spatial samples
+        ColorFunc color = nullptr; // spatial already filled by idctMCU
 
         void idctMCU(u8* spatial, const s16* data) const
         {
@@ -711,44 +709,47 @@ namespace mango::image::jpeg
     void idct8                          (u8* dest, const s16* data, const s16* qt);
     void idct12                         (u8* dest, const s16* data, const s16* qt);
 
-    void process_y_8bit                 (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_y_24bit                (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_y_32bit                (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_cmyk_rgba              (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+#define JPEG_COLOR_KERNEL(name) \
+    void name(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
+
+    JPEG_COLOR_KERNEL(process_y_8bit);
+    JPEG_COLOR_KERNEL(process_y_24bit);
+    JPEG_COLOR_KERNEL(process_y_32bit);
+    JPEG_COLOR_KERNEL(process_cmyk_rgba);
+    JPEG_COLOR_KERNEL(process_cmyk_store_rgba);
 
     // CMYK scanlines stored as C,M,Y,K in RGBA byte slots; converts in-place to display sRGB.
     bool transform_cmyk_surface_to_srgb(Surface& surface, ConstMemory icc);
     void simple_cmyk_surface_to_rgba(Surface& surface);
-    void process_ycbcr_8bit             (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    JPEG_COLOR_KERNEL(process_ycbcr_8bit);
 
-    void process_rgb_bgr               (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_rgb_rgb               (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_rgb_bgra              (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-    void process_rgb_rgba              (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    JPEG_COLOR_KERNEL(process_rgb_bgr);
+    JPEG_COLOR_KERNEL(process_rgb_rgb);
+    JPEG_COLOR_KERNEL(process_rgb_bgra);
+    JPEG_COLOR_KERNEL(process_rgb_rgba);
 
 #define JPEG_YCBCR_KERNEL(name) \
-    void name(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height); \
     void name##_color(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
 
-    void process_ycbcr_bgr              (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    JPEG_COLOR_KERNEL(process_ycbcr_bgr);
     JPEG_YCBCR_KERNEL(process_ycbcr_bgr_8x8);
     JPEG_YCBCR_KERNEL(process_ycbcr_bgr_8x16);
     JPEG_YCBCR_KERNEL(process_ycbcr_bgr_16x8);
     JPEG_YCBCR_KERNEL(process_ycbcr_bgr_16x16);
 
-    void process_ycbcr_rgb              (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    JPEG_COLOR_KERNEL(process_ycbcr_rgb);
     JPEG_YCBCR_KERNEL(process_ycbcr_rgb_8x8);
     JPEG_YCBCR_KERNEL(process_ycbcr_rgb_8x16);
     JPEG_YCBCR_KERNEL(process_ycbcr_rgb_16x8);
     JPEG_YCBCR_KERNEL(process_ycbcr_rgb_16x16);
 
-    void process_ycbcr_bgra             (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    JPEG_COLOR_KERNEL(process_ycbcr_bgra);
     JPEG_YCBCR_KERNEL(process_ycbcr_bgra_8x8);
     JPEG_YCBCR_KERNEL(process_ycbcr_bgra_8x16);
     JPEG_YCBCR_KERNEL(process_ycbcr_bgra_16x8);
     JPEG_YCBCR_KERNEL(process_ycbcr_bgra_16x16);
 
-    void process_ycbcr_rgba             (u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
+    JPEG_COLOR_KERNEL(process_ycbcr_rgba);
     JPEG_YCBCR_KERNEL(process_ycbcr_rgba_8x8);
     JPEG_YCBCR_KERNEL(process_ycbcr_rgba_8x16);
     JPEG_YCBCR_KERNEL(process_ycbcr_rgba_16x8);
@@ -817,6 +818,7 @@ namespace mango::image::jpeg
 #endif // MANGO_ENABLE_AVX2
 
 #undef JPEG_YCBCR_KERNEL
+#undef JPEG_COLOR_KERNEL
 
     SampleFormat getSampleFormat(const Format& format);
     ImageEncodeStatus encodeImage(Stream& stream, const Surface& surface, const ImageEncodeOptions& options);

--- a/source/mango/jpeg/jpeg.hpp
+++ b/source/mango/jpeg/jpeg.hpp
@@ -363,10 +363,16 @@ namespace mango::image::jpeg
         ColorSpace colorspace = ColorSpace::CMYK; // default
 
         void (*idct) (u8* dest, const s16* data, const s16* qt);
-        void (*idct2)(u8* dest0, u8* dest1, const s16* data0, const s16* data1, const s16* qt) = nullptr;
-        void (*idct4)(u8* dest0, u8* dest1, u8* dest2, u8* dest3,
-                      const s16* data0, const s16* data1, const s16* data2, const s16* data3, const s16* qt) = nullptr;
-        ColorFunc color = nullptr; // spatial already filled by idctMCU
+        // Counted linear 8x8s: dest/src step 64 samples, qt[idx + k] (table duplicated to 2*blocks).
+        void (*idct1)(u8* dest, const s16* src, const s16* const* qt, int blocks, int idx, int count) = nullptr;
+        void (*idct2)(u8* dest, const s16* src, const s16* const* qt, int blocks, int idx, int count) = nullptr;
+        void (*idct4)(u8* dest, const s16* src, const s16* const* qt, int blocks, int idx, int count) = nullptr;
+        ColorFunc color = nullptr; // spatial already filled by idctMCU / idctSpan
+
+        size_t spatialMCUBytes() const
+        {
+            return size_t(blocks) * 64;
+        }
 
         void idctMCU(u8* spatial, const s16* data) const
         {
@@ -376,22 +382,70 @@ namespace mango::image::jpeg
             }
         }
 
-        void idctMCU2(u8* spatial0, u8* spatial1, const s16* data0, const s16* data1) const
+        void idctSpan(u8* dest, const s16* data, int count) const
         {
+            // idx stays in [0, blocks). AVX-512 reads qt[idx + 0 .. +3], so keep
+            // three wraparound slots after the MCU pattern (Y-only is blocks==1).
+            const s16* qt[JPEG_MAX_BLOCKS_IN_MCU + 3];
             for (int i = 0; i < blocks; ++i)
             {
-                idct2(spatial0 + i * 64, spatial1 + i * 64,
-                      data0 + i * 64, data1 + i * 64, block[i].qt);
+                qt[i] = block[i].qt;
             }
-        }
-
-        void idctMCU4(u8* spatial0, u8* spatial1, u8* spatial2, u8* spatial3,
-                      const s16* data0, const s16* data1, const s16* data2, const s16* data3) const
-        {
-            for (int i = 0; i < blocks; ++i)
+            for (int i = 0; i < 3; ++i)
             {
-                idct4(spatial0 + i * 64, spatial1 + i * 64, spatial2 + i * 64, spatial3 + i * 64,
-                      data0 + i * 64, data1 + i * 64, data2 + i * 64, data3 + i * 64, block[i].qt);
+                qt[blocks + i] = qt[i];
+            }
+
+            int done = 0;
+            int idx = 0;
+
+            if (idct4)
+            {
+                const int n4 = count & ~3;
+                if (n4)
+                {
+                    idct4(dest, data, qt, blocks, idx, n4);
+                    dest += n4 * 64;
+                    data += n4 * 64;
+                    done += n4;
+                    idx += n4;
+                    while (idx >= blocks)
+                        idx -= blocks;
+                }
+            }
+
+            if (idct2)
+            {
+                const int n2 = (count - done) & ~1;
+                if (n2)
+                {
+                    idct2(dest, data, qt, blocks, idx, n2);
+                    dest += n2 * 64;
+                    data += n2 * 64;
+                    done += n2;
+                    idx += n2;
+                    while (idx >= blocks)
+                        idx -= blocks;
+                }
+            }
+
+            const int rest = count - done;
+            if (rest <= 0)
+                return;
+
+            if (idct1)
+            {
+                idct1(dest, data, qt, blocks, idx, rest);
+                return;
+            }
+
+            for (int i = 0; i < rest; ++i)
+            {
+                idct(dest, data, qt[idx]);
+                dest += 64;
+                data += 64;
+                if (++idx == blocks)
+                    idx = 0;
             }
         }
     };
@@ -801,6 +855,7 @@ namespace mango::image::jpeg
 #if defined(MANGO_ENABLE_SSE2)
 
     void idct_sse2                      (u8* dest, const s16* data, const s16* qt);
+    void idct_sse2_n                    (u8* dest, const s16* src, const s16* const* qt, int blocks, int idx, int count);
 
     JPEG_YCBCR_KERNEL(process_ycbcr_bgra_8x8_sse2);
     JPEG_YCBCR_KERNEL(process_ycbcr_bgra_8x16_sse2);
@@ -830,7 +885,7 @@ namespace mango::image::jpeg
 
 #if defined(MANGO_ENABLE_AVX2)
 
-    void idct_avx2                      (u8* dest0, u8* dest1, const s16* data0, const s16* data1, const s16* qt);
+    void idct_avx2                      (u8* dest, const s16* src, const s16* const* qt, int blocks, int idx, int count);
 
     JPEG_YCBCR_KERNEL(process_ycbcr_rgba_8x8_avx2);
 
@@ -838,8 +893,7 @@ namespace mango::image::jpeg
 
 #if defined(MANGO_ENABLE_AVX512)
 
-    void idct_avx512                    (u8* dest0, u8* dest1, u8* dest2, u8* dest3,
-                                         const s16* data0, const s16* data1, const s16* data2, const s16* data3, const s16* qt);
+    void idct_avx512                    (u8* dest, const s16* src, const s16* const* qt, int blocks, int idx, int count);
 
 #endif // MANGO_ENABLE_AVX512
 

--- a/source/mango/jpeg/jpeg.hpp
+++ b/source/mango/jpeg/jpeg.hpp
@@ -364,6 +364,8 @@ namespace mango::image::jpeg
 
         void (*idct) (u8* dest, const s16* data, const s16* qt);
         void (*idct2)(u8* dest0, u8* dest1, const s16* data0, const s16* data1, const s16* qt) = nullptr;
+        void (*idct4)(u8* dest0, u8* dest1, u8* dest2, u8* dest3,
+                      const s16* data0, const s16* data1, const s16* data2, const s16* data3, const s16* qt) = nullptr;
         ColorFunc color = nullptr; // spatial already filled by idctMCU
 
         void idctMCU(u8* spatial, const s16* data) const
@@ -380,6 +382,16 @@ namespace mango::image::jpeg
             {
                 idct2(spatial0 + i * 64, spatial1 + i * 64,
                       data0 + i * 64, data1 + i * 64, block[i].qt);
+            }
+        }
+
+        void idctMCU4(u8* spatial0, u8* spatial1, u8* spatial2, u8* spatial3,
+                      const s16* data0, const s16* data1, const s16* data2, const s16* data3) const
+        {
+            for (int i = 0; i < blocks; ++i)
+            {
+                idct4(spatial0 + i * 64, spatial1 + i * 64, spatial2 + i * 64, spatial3 + i * 64,
+                      data0 + i * 64, data1 + i * 64, data2 + i * 64, data3 + i * 64, block[i].qt);
             }
         }
     };
@@ -823,6 +835,13 @@ namespace mango::image::jpeg
     JPEG_YCBCR_KERNEL(process_ycbcr_rgba_8x8_avx2);
 
 #endif // MANGO_ENABLE_AVX2
+
+#if defined(MANGO_ENABLE_AVX512)
+
+    void idct_avx512                    (u8* dest0, u8* dest1, u8* dest2, u8* dest3,
+                                         const s16* data0, const s16* data1, const s16* data2, const s16* data3, const s16* qt);
+
+#endif // MANGO_ENABLE_AVX512
 
 #undef JPEG_YCBCR_KERNEL
 #undef JPEG_COLOR_KERNEL

--- a/source/mango/jpeg/jpeg.hpp
+++ b/source/mango/jpeg/jpeg.hpp
@@ -362,19 +362,24 @@ namespace mango::image::jpeg
 
         ColorSpace colorspace = ColorSpace::CMYK; // default
 
-        // Byte offset in the per-MCU spatial slot for Huffman block i.
-        // Sequential (i * 64) except SIMD 16x16, which shuffles Y1/Y2 so color
-        // can load a vertical pair with a 32-byte stride (Y0@0, Y2@64, Y1@128, Y3@192).
-        int idct_offset[JPEG_MAX_BLOCKS_IN_MCU];
-
         void (*idct) (u8* dest, const s16* data, const s16* qt);
+        void (*idct2)(u8* dest0, u8* dest1, const s16* data0, const s16* data1, const s16* qt) = nullptr;
         ColorFunc color = nullptr; // spatial already filled by idctMCU
 
         void idctMCU(u8* spatial, const s16* data) const
         {
             for (int i = 0; i < blocks; ++i)
             {
-                idct(spatial + idct_offset[i], data + i * 64, block[i].qt);
+                idct(spatial + i * 64, data + i * 64, block[i].qt);
+            }
+        }
+
+        void idctMCU2(u8* spatial0, u8* spatial1, const s16* data0, const s16* data1) const
+        {
+            for (int i = 0; i < blocks; ++i)
+            {
+                idct2(spatial0 + i * 64, spatial1 + i * 64,
+                      data0 + i * 64, data1 + i * 64, block[i].qt);
             }
         }
     };
@@ -812,6 +817,8 @@ namespace mango::image::jpeg
 #endif // MANGO_ENABLE_SSE4_1
 
 #if defined(MANGO_ENABLE_AVX2)
+
+    void idct_avx2                      (u8* dest0, u8* dest1, const s16* data0, const s16* data1, const s16* qt);
 
     JPEG_YCBCR_KERNEL(process_ycbcr_rgba_8x8_avx2);
 

--- a/source/mango/jpeg/jpeg_decode.cpp
+++ b/source/mango/jpeg/jpeg_decode.cpp
@@ -16,8 +16,6 @@
 namespace mango::image::jpeg
 {
 
-    void process_cmyk_store_rgba(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-
     // ----------------------------------------------------------------------------
     // utilities
     // ----------------------------------------------------------------------------
@@ -2591,14 +2589,10 @@ namespace mango::image::jpeg
 
         // configure block processing
 
-        ProcessFunc process_y           = nullptr;
-        ProcessFunc process_cmyk        = process_cmyk_rgba;
-        ProcessFunc process_rgb         = nullptr;
-        ProcessFunc process_ycbcr       = nullptr;
-        ProcessFunc process_ycbcr_8x8   = nullptr;
-        ProcessFunc process_ycbcr_8x16  = nullptr;
-        ProcessFunc process_ycbcr_16x8  = nullptr;
-        ProcessFunc process_ycbcr_16x16 = nullptr;
+        ColorFunc color_y     = nullptr;
+        ColorFunc color_cmyk  = process_cmyk_rgba;
+        ColorFunc color_rgb   = nullptr;
+        ColorFunc color_ycbcr = nullptr;
 
         ColorFunc color_ycbcr_8x8   = nullptr;
         ColorFunc color_ycbcr_8x16  = nullptr;
@@ -2607,46 +2601,46 @@ namespace mango::image::jpeg
         bool simd_16x16_shuffle = false;
 
 #define BIND_YCBCR(size, func) \
-        do { process_ycbcr_##size = (func); color_ycbcr_##size = (func##_color); } while (0)
+        do { color_ycbcr_##size = (func##_color); } while (0)
 
         switch (sample)
         {
             case SampleType::U8_Y:
-                process_y           = process_y_8bit;
-                process_rgb         = nullptr; // could support if compute luminance from RGB
-                process_ycbcr       = process_ycbcr_8bit;
+                color_y     = process_y_8bit;
+                color_rgb   = nullptr; // could support if compute luminance from RGB
+                color_ycbcr = process_ycbcr_8bit;
                 break;
             case SampleType::U8_BGR:
-                process_y           = process_y_24bit;
-                process_rgb         = process_rgb_bgr;
-                process_ycbcr       = process_ycbcr_bgr;
+                color_y     = process_y_24bit;
+                color_rgb   = process_rgb_bgr;
+                color_ycbcr = process_ycbcr_bgr;
                 BIND_YCBCR(8x8,   process_ycbcr_bgr_8x8);
                 BIND_YCBCR(8x16,  process_ycbcr_bgr_8x16);
                 BIND_YCBCR(16x8,  process_ycbcr_bgr_16x8);
                 BIND_YCBCR(16x16, process_ycbcr_bgr_16x16);
                 break;
             case SampleType::U8_RGB:
-                process_y           = process_y_24bit;
-                process_rgb         = process_rgb_rgb;
-                process_ycbcr       = process_ycbcr_rgb;
+                color_y     = process_y_24bit;
+                color_rgb   = process_rgb_rgb;
+                color_ycbcr = process_ycbcr_rgb;
                 BIND_YCBCR(8x8,   process_ycbcr_rgb_8x8);
                 BIND_YCBCR(8x16,  process_ycbcr_rgb_8x16);
                 BIND_YCBCR(16x8,  process_ycbcr_rgb_16x8);
                 BIND_YCBCR(16x16, process_ycbcr_rgb_16x16);
                 break;
             case SampleType::U8_BGRA:
-                process_y           = process_y_32bit;
-                process_rgb         = process_rgb_bgra;
-                process_ycbcr       = process_ycbcr_bgra;
+                color_y     = process_y_32bit;
+                color_rgb   = process_rgb_bgra;
+                color_ycbcr = process_ycbcr_bgra;
                 BIND_YCBCR(8x8,   process_ycbcr_bgra_8x8);
                 BIND_YCBCR(8x16,  process_ycbcr_bgra_8x16);
                 BIND_YCBCR(16x8,  process_ycbcr_bgra_16x8);
                 BIND_YCBCR(16x16, process_ycbcr_bgra_16x16);
                 break;
             case SampleType::U8_RGBA:
-                process_y           = process_y_32bit;
-                process_rgb         = process_rgb_rgba;
-                process_ycbcr       = process_ycbcr_rgba;
+                color_y     = process_y_32bit;
+                color_rgb   = process_rgb_rgba;
+                color_ycbcr = process_ycbcr_rgba;
                 BIND_YCBCR(8x8,   process_ycbcr_rgba_8x8);
                 BIND_YCBCR(8x16,  process_ycbcr_rgba_8x16);
                 BIND_YCBCR(16x8,  process_ycbcr_rgba_16x8);
@@ -2829,12 +2823,12 @@ namespace mango::image::jpeg
         switch (m_components)
         {
             case 1:
-                processState.process = process_y;
+                processState.color = color_y;
                 id = "Y";
                 break;
 
             case 3:
-                processState.process = process_ycbcr;
+                processState.color = color_ycbcr;
                 id = "YCbCr";
 
                 // detect optimized cases
@@ -2842,9 +2836,8 @@ namespace mango::image::jpeg
                 {
                     if (xblock == 8 && yblock == 8)
                     {
-                        if (process_ycbcr_8x8)
+                        if (color_ycbcr_8x8)
                         {
-                            processState.process = process_ycbcr_8x8;
                             processState.color = color_ycbcr_8x8;
                             id = fmt::format("YCbCr 8x8 {}", simd_8x8);
                         }
@@ -2852,9 +2845,8 @@ namespace mango::image::jpeg
 
                     if (xblock == 8 && yblock == 16)
                     {
-                        if (process_ycbcr_8x16)
+                        if (color_ycbcr_8x16)
                         {
-                            processState.process = process_ycbcr_8x16;
                             processState.color = color_ycbcr_8x16;
                             id = fmt::format("YCbCr 8x16 {}", simd_8x16);
                         }
@@ -2862,9 +2854,8 @@ namespace mango::image::jpeg
 
                     if (xblock == 16 && yblock == 8)
                     {
-                        if (process_ycbcr_16x8)
+                        if (color_ycbcr_16x8)
                         {
-                            processState.process = process_ycbcr_16x8;
                             processState.color = color_ycbcr_16x8;
                             id = fmt::format("YCbCr 16x8 {}", simd_16x8);
                         }
@@ -2872,9 +2863,8 @@ namespace mango::image::jpeg
 
                     if (xblock == 16 && yblock == 16)
                     {
-                        if (process_ycbcr_16x16)
+                        if (color_ycbcr_16x16)
                         {
-                            processState.process = process_ycbcr_16x16;
                             processState.color = color_ycbcr_16x16;
                             id = fmt::format("YCbCr 16x16 {}", simd_16x16);
 
@@ -2892,12 +2882,12 @@ namespace mango::image::jpeg
             case 4:
                 if (getCmykIcc().size)
                 {
-                    processState.process = process_cmyk_store_rgba;
+                    processState.color = process_cmyk_store_rgba;
                     m_cmyk_store_mode = true;
                 }
                 else
                 {
-                    processState.process = process_cmyk;
+                    processState.color = color_cmyk;
                     m_cmyk_store_mode = false;
                 }
                 id = "CMYK";
@@ -2906,8 +2896,7 @@ namespace mango::image::jpeg
 
         if (m_rgb_colorspace || options.jpeg_colorspace_rgb)
         {
-            processState.process = process_rgb;
-            processState.color = nullptr;
+            processState.color = color_rgb;
             id = "RGB";
         }
 
@@ -4067,17 +4056,6 @@ namespace mango::image::jpeg
         const int mcu_data_size = blocks_in_mcu * 64;
         const size_t xstride = m_sink.surface->format.bytes() * xblock;
 
-        if (!processState.color)
-        {
-            for (int i = 0; i < count; ++i)
-            {
-                process_and_clip(dest, stride, data, width, height);
-                data += mcu_data_size;
-                dest += xstride;
-            }
-            return;
-        }
-
         alignas(64) u8 slab[JPEG_MCU_TILE * JPEG_MAX_SAMPLES_IN_MCU];
 
         int remaining = count;
@@ -4111,37 +4089,9 @@ namespace mango::image::jpeg
 
     void StreamDecoder::process_and_clip(u8* dest, size_t stride, const s16* data, int width, int height)
     {
-        if (processState.color)
-        {
-            alignas(64) u8 spatial[JPEG_MAX_SAMPLES_IN_MCU];
-            processState.idctMCU(spatial, data);
-            color_and_clip(dest, stride, spatial, width, height);
-            return;
-        }
-
-        if (xblock != width || yblock != height)
-        {
-            u8 temp[JPEG_MAX_SAMPLES_IN_MCU * 4];
-
-            const int bytes_per_scan = width * m_sink.surface->format.bytes();
-            const int block_stride = xblock * 4;
-            u8* src = temp;
-
-            processState.process(temp, block_stride, data, &processState, width, height);
-
-            // clipping
-            for (int y = 0; y < height; ++y)
-            {
-                std::memcpy(dest, src, bytes_per_scan);
-                src += block_stride;
-                dest += stride;
-            }
-        }
-        else
-        {
-            // fast-path (no clipping required)
-            processState.process(dest, stride, data, &processState, width, height);
-        }
+        alignas(64) u8 spatial[JPEG_MAX_SAMPLES_IN_MCU];
+        processState.idctMCU(spatial, data);
+        color_and_clip(dest, stride, spatial, width, height);
     }
 
     void StreamDecoder::blit_and_update(const ImageDecodeRect& rect)

--- a/source/mango/jpeg/jpeg_decode.cpp
+++ b/source/mango/jpeg/jpeg_decode.cpp
@@ -2563,12 +2563,15 @@ namespace mango::image::jpeg
 
         processState.idct = idct8;
         processState.idct2 = nullptr;
+        processState.idct4 = nullptr;
+
+        m_idct_name = "scalar (8 bit)";
 
 #if defined(MANGO_ENABLE_NEON)
         if (flags & ARM_NEON)
         {
             processState.idct = idct_neon;
-            m_idct_name = "iDCT: NEON";
+            m_idct_name = "NEON";
         }
 #endif
 
@@ -2576,7 +2579,7 @@ namespace mango::image::jpeg
         if (flags & INTEL_SSE2)
         {
             processState.idct = idct_sse2;
-            m_idct_name = "iDCT: SSE2";
+            m_idct_name = "SSE2";
         }
 #endif
 
@@ -2584,7 +2587,15 @@ namespace mango::image::jpeg
         if (flags & INTEL_AVX2)
         {
             processState.idct2 = idct_avx2;
-            m_idct_name = "iDCT: AVX2";
+            m_idct_name = "AVX2";
+        }
+#endif
+
+#if defined(MANGO_ENABLE_AVX512)
+        if ((flags & INTEL_AVX512F) && (flags & INTEL_AVX512BW))
+        {
+            processState.idct4 = idct_avx512;
+            m_idct_name = "AVX-512";
         }
 #endif
 
@@ -2594,7 +2605,8 @@ namespace mango::image::jpeg
             // This will round down to 8 bit precision until we have a 12 bit capable color conversion
             processState.idct = idct12;
             processState.idct2 = nullptr;
-            m_idct_name = "iDCT: 12 bit";
+            processState.idct4 = nullptr;
+            m_idct_name = "scalar (12 bit)";
         }
 
         // configure block processing
@@ -2895,7 +2907,8 @@ namespace mango::image::jpeg
         m_ycbcr_name = id;
 
         printLine(Print::Debug, "[ConfigureCPU]");
-        printLine(Print::Debug, "  Decoder: {}", id);
+        printLine(Print::Debug, "  Color: {}", id);
+        printLine(Print::Debug, "  iDCT: {}", m_idct_name);
         printLine(Print::Debug, "");
     }
 
@@ -3072,7 +3085,7 @@ namespace mango::image::jpeg
 
         if (!m_idct_name.empty())
         {
-            info += ", ";
+            info += ", iDCT: ";
             info += m_idct_name;
         }
 
@@ -4054,6 +4067,21 @@ namespace mango::image::jpeg
             const int n = std::min(remaining, JPEG_MCU_TILE);
 
             int i = 0;
+            if (processState.idct4)
+            {
+                for (; i + 3 < n; i += 4)
+                {
+                    processState.idctMCU4(
+                        slab + (i + 0) * JPEG_MAX_SAMPLES_IN_MCU,
+                        slab + (i + 1) * JPEG_MAX_SAMPLES_IN_MCU,
+                        slab + (i + 2) * JPEG_MAX_SAMPLES_IN_MCU,
+                        slab + (i + 3) * JPEG_MAX_SAMPLES_IN_MCU,
+                        data + (i + 0) * mcu_data_size,
+                        data + (i + 1) * mcu_data_size,
+                        data + (i + 2) * mcu_data_size,
+                        data + (i + 3) * mcu_data_size);
+                }
+            }
             if (processState.idct2)
             {
                 for (; i + 1 < n; i += 2)

--- a/source/mango/jpeg/jpeg_decode.cpp
+++ b/source/mango/jpeg/jpeg_decode.cpp
@@ -2562,6 +2562,7 @@ namespace mango::image::jpeg
         // configure idct
 
         processState.idct = idct8;
+        processState.idct2 = nullptr;
 
 #if defined(MANGO_ENABLE_NEON)
         if (flags & ARM_NEON)
@@ -2579,11 +2580,20 @@ namespace mango::image::jpeg
         }
 #endif
 
+#if defined(MANGO_ENABLE_AVX2)
+        if (flags & INTEL_AVX2)
+        {
+            processState.idct2 = idct_avx2;
+            m_idct_name = "iDCT: AVX2";
+        }
+#endif
+
         if (m_precision == 12)
         {
             // Force 12 bit idct
             // This will round down to 8 bit precision until we have a 12 bit capable color conversion
             processState.idct = idct12;
+            processState.idct2 = nullptr;
             m_idct_name = "iDCT: 12 bit";
         }
 
@@ -2598,7 +2608,6 @@ namespace mango::image::jpeg
         ColorFunc color_ycbcr_8x16  = nullptr;
         ColorFunc color_ycbcr_16x8  = nullptr;
         ColorFunc color_ycbcr_16x16 = nullptr;
-        bool simd_16x16_shuffle = false;
 
 #define BIND_YCBCR(size, func) \
         do { color_ycbcr_##size = (func##_color); } while (0)
@@ -2670,7 +2679,6 @@ namespace mango::image::jpeg
                     simd_8x16  = "NEON";
                     simd_16x8  = "NEON";
                     simd_16x16 = "NEON";
-                    simd_16x16_shuffle = true;
                     break;
                 case SampleType::U8_RGB:
                     BIND_YCBCR(8x8,   process_ycbcr_rgb_8x8_neon);
@@ -2681,7 +2689,6 @@ namespace mango::image::jpeg
                     simd_8x16  = "NEON";
                     simd_16x8  = "NEON";
                     simd_16x16 = "NEON";
-                    simd_16x16_shuffle = true;
                     break;
                 case SampleType::U8_BGRA:
                     BIND_YCBCR(8x8,   process_ycbcr_bgra_8x8_neon);
@@ -2692,7 +2699,6 @@ namespace mango::image::jpeg
                     simd_8x16  = "NEON";
                     simd_16x8  = "NEON";
                     simd_16x16 = "NEON";
-                    simd_16x16_shuffle = true;
                     break;
                 case SampleType::U8_RGBA:
                     BIND_YCBCR(8x8,   process_ycbcr_rgba_8x8_neon);
@@ -2703,7 +2709,6 @@ namespace mango::image::jpeg
                     simd_8x16  = "NEON";
                     simd_16x8  = "NEON";
                     simd_16x16 = "NEON";
-                    simd_16x16_shuffle = true;
                     break;
             }
         }
@@ -2731,7 +2736,6 @@ namespace mango::image::jpeg
                     simd_8x16  = "SSE2";
                     simd_16x8  = "SSE2";
                     simd_16x16 = "SSE2";
-                    simd_16x16_shuffle = true;
                     break;
                 case SampleType::U8_RGBA:
                     BIND_YCBCR(8x8,   process_ycbcr_rgba_8x8_sse2);
@@ -2742,7 +2746,6 @@ namespace mango::image::jpeg
                     simd_8x16  = "SSE2";
                     simd_16x8  = "SSE2";
                     simd_16x16 = "SSE2";
-                    simd_16x16_shuffle = true;
                     break;
             }
         }
@@ -2766,7 +2769,6 @@ namespace mango::image::jpeg
                     simd_8x16  = "SSE4.1";
                     simd_16x8  = "SSE4.1";
                     simd_16x16 = "SSE4.1";
-                    simd_16x16_shuffle = true;
                     break;
                 case SampleType::U8_RGB:
                     BIND_YCBCR(8x8,   process_ycbcr_rgb_8x8_sse41);
@@ -2777,7 +2779,6 @@ namespace mango::image::jpeg
                     simd_8x16  = "SSE4.1";
                     simd_16x8  = "SSE4.1";
                     simd_16x16 = "SSE4.1";
-                    simd_16x16_shuffle = true;
                     break;
                 case SampleType::U8_BGRA:
                     break;
@@ -2814,10 +2815,6 @@ namespace mango::image::jpeg
         std::string id;
 
         processState.color = nullptr;
-        for (int i = 0; i < JPEG_MAX_BLOCKS_IN_MCU; ++i)
-        {
-            processState.idct_offset[i] = i * 64;
-        }
 
         // determine jpeg type -> select innerloops
         switch (m_components)
@@ -2867,13 +2864,6 @@ namespace mango::image::jpeg
                         {
                             processState.color = color_ycbcr_16x16;
                             id = fmt::format("YCbCr 16x16 {}", simd_16x16);
-
-                            if (simd_16x16_shuffle)
-                            {
-                                // Huffman Y0,Y1,Y2,Y3,Cb,Cr → spatial Y0,Y2,Y1,Y3,Cb,Cr
-                                processState.idct_offset[1] = 128;
-                                processState.idct_offset[2] = 64;
-                            }
                         }
                     }
                 }
@@ -4063,7 +4053,19 @@ namespace mango::image::jpeg
         {
             const int n = std::min(remaining, JPEG_MCU_TILE);
 
-            for (int i = 0; i < n; ++i)
+            int i = 0;
+            if (processState.idct2)
+            {
+                for (; i + 1 < n; i += 2)
+                {
+                    processState.idctMCU2(
+                        slab + i * JPEG_MAX_SAMPLES_IN_MCU,
+                        slab + (i + 1) * JPEG_MAX_SAMPLES_IN_MCU,
+                        data + i * mcu_data_size,
+                        data + (i + 1) * mcu_data_size);
+                }
+            }
+            for (; i < n; ++i)
             {
                 processState.idctMCU(slab + i * JPEG_MAX_SAMPLES_IN_MCU, data + i * mcu_data_size);
             }

--- a/source/mango/jpeg/jpeg_decode.cpp
+++ b/source/mango/jpeg/jpeg_decode.cpp
@@ -2562,6 +2562,7 @@ namespace mango::image::jpeg
         // configure idct
 
         processState.idct = idct8;
+        processState.idct1 = nullptr;
         processState.idct2 = nullptr;
         processState.idct4 = nullptr;
 
@@ -2579,6 +2580,7 @@ namespace mango::image::jpeg
         if (flags & INTEL_SSE2)
         {
             processState.idct = idct_sse2;
+            processState.idct1 = idct_sse2_n;
             m_idct_name = "SSE2";
         }
 #endif
@@ -2604,6 +2606,7 @@ namespace mango::image::jpeg
             // Force 12 bit idct
             // This will round down to 8 bit precision until we have a 12 bit capable color conversion
             processState.idct = idct12;
+            processState.idct1 = nullptr;
             processState.idct2 = nullptr;
             processState.idct4 = nullptr;
             m_idct_name = "scalar (12 bit)";
@@ -4058,6 +4061,7 @@ namespace mango::image::jpeg
     {
         const int mcu_data_size = blocks_in_mcu * 64;
         const size_t xstride = m_sink.surface->format.bytes() * xblock;
+        const size_t spatial_stride = processState.spatialMCUBytes();
 
         alignas(64) u8 slab[JPEG_MCU_TILE * JPEG_MAX_SAMPLES_IN_MCU];
 
@@ -4066,37 +4070,7 @@ namespace mango::image::jpeg
         {
             const int n = std::min(remaining, JPEG_MCU_TILE);
 
-            int i = 0;
-            if (processState.idct4)
-            {
-                for (; i + 3 < n; i += 4)
-                {
-                    processState.idctMCU4(
-                        slab + (i + 0) * JPEG_MAX_SAMPLES_IN_MCU,
-                        slab + (i + 1) * JPEG_MAX_SAMPLES_IN_MCU,
-                        slab + (i + 2) * JPEG_MAX_SAMPLES_IN_MCU,
-                        slab + (i + 3) * JPEG_MAX_SAMPLES_IN_MCU,
-                        data + (i + 0) * mcu_data_size,
-                        data + (i + 1) * mcu_data_size,
-                        data + (i + 2) * mcu_data_size,
-                        data + (i + 3) * mcu_data_size);
-                }
-            }
-            if (processState.idct2)
-            {
-                for (; i + 1 < n; i += 2)
-                {
-                    processState.idctMCU2(
-                        slab + i * JPEG_MAX_SAMPLES_IN_MCU,
-                        slab + (i + 1) * JPEG_MAX_SAMPLES_IN_MCU,
-                        data + i * mcu_data_size,
-                        data + (i + 1) * mcu_data_size);
-                }
-            }
-            for (; i < n; ++i)
-            {
-                processState.idctMCU(slab + i * JPEG_MAX_SAMPLES_IN_MCU, data + i * mcu_data_size);
-            }
+            processState.idctSpan(slab, data, n * processState.blocks);
 
             if (width == xblock && height == yblock)
             {
@@ -4107,7 +4081,7 @@ namespace mango::image::jpeg
             {
                 for (int i = 0; i < n; ++i)
                 {
-                    color_and_clip(dest, stride, slab + i * JPEG_MAX_SAMPLES_IN_MCU, width, height);
+                    color_and_clip(dest, stride, slab + i * spatial_stride, width, height);
                     dest += xstride;
                 }
             }

--- a/source/mango/jpeg/jpeg_decode.cpp
+++ b/source/mango/jpeg/jpeg_decode.cpp
@@ -2591,8 +2591,6 @@ namespace mango::image::jpeg
 
         // configure block processing
 
-        using ProcessFunc = void (*)(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height);
-
         ProcessFunc process_y           = nullptr;
         ProcessFunc process_cmyk        = process_cmyk_rgba;
         ProcessFunc process_rgb         = nullptr;
@@ -2602,52 +2600,57 @@ namespace mango::image::jpeg
         ProcessFunc process_ycbcr_16x8  = nullptr;
         ProcessFunc process_ycbcr_16x16 = nullptr;
 
+        ColorFunc color_ycbcr_8x8   = nullptr;
+        ColorFunc color_ycbcr_8x16  = nullptr;
+        ColorFunc color_ycbcr_16x8  = nullptr;
+        ColorFunc color_ycbcr_16x16 = nullptr;
+        bool simd_16x16_shuffle = false;
+
+#define BIND_YCBCR(size, func) \
+        do { process_ycbcr_##size = (func); color_ycbcr_##size = (func##_color); } while (0)
+
         switch (sample)
         {
             case SampleType::U8_Y:
                 process_y           = process_y_8bit;
                 process_rgb         = nullptr; // could support if compute luminance from RGB
                 process_ycbcr       = process_ycbcr_8bit;
-                process_ycbcr_8x8   = nullptr;
-                process_ycbcr_8x16  = nullptr;
-                process_ycbcr_16x8  = nullptr;
-                process_ycbcr_16x16 = nullptr;
                 break;
             case SampleType::U8_BGR:
                 process_y           = process_y_24bit;
                 process_rgb         = process_rgb_bgr;
                 process_ycbcr       = process_ycbcr_bgr;
-                process_ycbcr_8x8   = process_ycbcr_bgr_8x8;
-                process_ycbcr_8x16  = process_ycbcr_bgr_8x16;
-                process_ycbcr_16x8  = process_ycbcr_bgr_16x8;
-                process_ycbcr_16x16 = process_ycbcr_bgr_16x16;
+                BIND_YCBCR(8x8,   process_ycbcr_bgr_8x8);
+                BIND_YCBCR(8x16,  process_ycbcr_bgr_8x16);
+                BIND_YCBCR(16x8,  process_ycbcr_bgr_16x8);
+                BIND_YCBCR(16x16, process_ycbcr_bgr_16x16);
                 break;
             case SampleType::U8_RGB:
                 process_y           = process_y_24bit;
                 process_rgb         = process_rgb_rgb;
                 process_ycbcr       = process_ycbcr_rgb;
-                process_ycbcr_8x8   = process_ycbcr_rgb_8x8;
-                process_ycbcr_8x16  = process_ycbcr_rgb_8x16;
-                process_ycbcr_16x8  = process_ycbcr_rgb_16x8;
-                process_ycbcr_16x16 = process_ycbcr_rgb_16x16;
+                BIND_YCBCR(8x8,   process_ycbcr_rgb_8x8);
+                BIND_YCBCR(8x16,  process_ycbcr_rgb_8x16);
+                BIND_YCBCR(16x8,  process_ycbcr_rgb_16x8);
+                BIND_YCBCR(16x16, process_ycbcr_rgb_16x16);
                 break;
             case SampleType::U8_BGRA:
                 process_y           = process_y_32bit;
                 process_rgb         = process_rgb_bgra;
                 process_ycbcr       = process_ycbcr_bgra;
-                process_ycbcr_8x8   = process_ycbcr_bgra_8x8;
-                process_ycbcr_8x16  = process_ycbcr_bgra_8x16;
-                process_ycbcr_16x8  = process_ycbcr_bgra_16x8;
-                process_ycbcr_16x16 = process_ycbcr_bgra_16x16;
+                BIND_YCBCR(8x8,   process_ycbcr_bgra_8x8);
+                BIND_YCBCR(8x16,  process_ycbcr_bgra_8x16);
+                BIND_YCBCR(16x8,  process_ycbcr_bgra_16x8);
+                BIND_YCBCR(16x16, process_ycbcr_bgra_16x16);
                 break;
             case SampleType::U8_RGBA:
                 process_y           = process_y_32bit;
                 process_rgb         = process_rgb_rgba;
                 process_ycbcr       = process_ycbcr_rgba;
-                process_ycbcr_8x8   = process_ycbcr_rgba_8x8;
-                process_ycbcr_8x16  = process_ycbcr_rgba_8x16;
-                process_ycbcr_16x8  = process_ycbcr_rgba_16x8;
-                process_ycbcr_16x16 = process_ycbcr_rgba_16x16;
+                BIND_YCBCR(8x8,   process_ycbcr_rgba_8x8);
+                BIND_YCBCR(8x16,  process_ycbcr_rgba_8x16);
+                BIND_YCBCR(16x8,  process_ycbcr_rgba_16x8);
+                BIND_YCBCR(16x16, process_ycbcr_rgba_16x16);
                 break;
         }
 
@@ -2665,44 +2668,48 @@ namespace mango::image::jpeg
                 case SampleType::U8_Y:
                     break;
                 case SampleType::U8_BGR:
-                    process_ycbcr_8x8   = process_ycbcr_bgr_8x8_neon;
-                    process_ycbcr_8x16  = process_ycbcr_bgr_8x16_neon;
-                    process_ycbcr_16x8  = process_ycbcr_bgr_16x8_neon;
-                    process_ycbcr_16x16 = process_ycbcr_bgr_16x16_neon;
+                    BIND_YCBCR(8x8,   process_ycbcr_bgr_8x8_neon);
+                    BIND_YCBCR(8x16,  process_ycbcr_bgr_8x16_neon);
+                    BIND_YCBCR(16x8,  process_ycbcr_bgr_16x8_neon);
+                    BIND_YCBCR(16x16, process_ycbcr_bgr_16x16_neon);
                     simd_8x8   = "NEON";
                     simd_8x16  = "NEON";
                     simd_16x8  = "NEON";
                     simd_16x16 = "NEON";
+                    simd_16x16_shuffle = true;
                     break;
                 case SampleType::U8_RGB:
-                    process_ycbcr_8x8   = process_ycbcr_rgb_8x8_neon;
-                    process_ycbcr_8x16  = process_ycbcr_rgb_8x16_neon;
-                    process_ycbcr_16x8  = process_ycbcr_rgb_16x8_neon;
-                    process_ycbcr_16x16 = process_ycbcr_rgb_16x16_neon;
+                    BIND_YCBCR(8x8,   process_ycbcr_rgb_8x8_neon);
+                    BIND_YCBCR(8x16,  process_ycbcr_rgb_8x16_neon);
+                    BIND_YCBCR(16x8,  process_ycbcr_rgb_16x8_neon);
+                    BIND_YCBCR(16x16, process_ycbcr_rgb_16x16_neon);
                     simd_8x8   = "NEON";
                     simd_8x16  = "NEON";
                     simd_16x8  = "NEON";
                     simd_16x16 = "NEON";
+                    simd_16x16_shuffle = true;
                     break;
                 case SampleType::U8_BGRA:
-                    process_ycbcr_8x8   = process_ycbcr_bgra_8x8_neon;
-                    process_ycbcr_8x16  = process_ycbcr_bgra_8x16_neon;
-                    process_ycbcr_16x8  = process_ycbcr_bgra_16x8_neon;
-                    process_ycbcr_16x16 = process_ycbcr_bgra_16x16_neon;
+                    BIND_YCBCR(8x8,   process_ycbcr_bgra_8x8_neon);
+                    BIND_YCBCR(8x16,  process_ycbcr_bgra_8x16_neon);
+                    BIND_YCBCR(16x8,  process_ycbcr_bgra_16x8_neon);
+                    BIND_YCBCR(16x16, process_ycbcr_bgra_16x16_neon);
                     simd_8x8   = "NEON";
                     simd_8x16  = "NEON";
                     simd_16x8  = "NEON";
                     simd_16x16 = "NEON";
+                    simd_16x16_shuffle = true;
                     break;
                 case SampleType::U8_RGBA:
-                    process_ycbcr_8x8   = process_ycbcr_rgba_8x8_neon;
-                    process_ycbcr_8x16  = process_ycbcr_rgba_8x16_neon;
-                    process_ycbcr_16x8  = process_ycbcr_rgba_16x8_neon;
-                    process_ycbcr_16x16 = process_ycbcr_rgba_16x16_neon;
+                    BIND_YCBCR(8x8,   process_ycbcr_rgba_8x8_neon);
+                    BIND_YCBCR(8x16,  process_ycbcr_rgba_8x16_neon);
+                    BIND_YCBCR(16x8,  process_ycbcr_rgba_16x8_neon);
+                    BIND_YCBCR(16x16, process_ycbcr_rgba_16x16_neon);
                     simd_8x8   = "NEON";
                     simd_8x16  = "NEON";
                     simd_16x8  = "NEON";
                     simd_16x16 = "NEON";
+                    simd_16x16_shuffle = true;
                     break;
             }
         }
@@ -2722,24 +2729,26 @@ namespace mango::image::jpeg
                 case SampleType::U8_RGB:
                     break;
                 case SampleType::U8_BGRA:
-                    process_ycbcr_8x8   = process_ycbcr_bgra_8x8_sse2;
-                    process_ycbcr_8x16  = process_ycbcr_bgra_8x16_sse2;
-                    process_ycbcr_16x8  = process_ycbcr_bgra_16x8_sse2;
-                    process_ycbcr_16x16 = process_ycbcr_bgra_16x16_sse2;
+                    BIND_YCBCR(8x8,   process_ycbcr_bgra_8x8_sse2);
+                    BIND_YCBCR(8x16,  process_ycbcr_bgra_8x16_sse2);
+                    BIND_YCBCR(16x8,  process_ycbcr_bgra_16x8_sse2);
+                    BIND_YCBCR(16x16, process_ycbcr_bgra_16x16_sse2);
                     simd_8x8   = "SSE2";
                     simd_8x16  = "SSE2";
                     simd_16x8  = "SSE2";
                     simd_16x16 = "SSE2";
+                    simd_16x16_shuffle = true;
                     break;
                 case SampleType::U8_RGBA:
-                    process_ycbcr_8x8   = process_ycbcr_rgba_8x8_sse2;
-                    process_ycbcr_8x16  = process_ycbcr_rgba_8x16_sse2;
-                    process_ycbcr_16x8  = process_ycbcr_rgba_16x8_sse2;
-                    process_ycbcr_16x16 = process_ycbcr_rgba_16x16_sse2;
+                    BIND_YCBCR(8x8,   process_ycbcr_rgba_8x8_sse2);
+                    BIND_YCBCR(8x16,  process_ycbcr_rgba_8x16_sse2);
+                    BIND_YCBCR(16x8,  process_ycbcr_rgba_16x8_sse2);
+                    BIND_YCBCR(16x16, process_ycbcr_rgba_16x16_sse2);
                     simd_8x8   = "SSE2";
                     simd_8x16  = "SSE2";
                     simd_16x8  = "SSE2";
                     simd_16x16 = "SSE2";
+                    simd_16x16_shuffle = true;
                     break;
             }
         }
@@ -2755,24 +2764,26 @@ namespace mango::image::jpeg
                 case SampleType::U8_Y:
                     break;
                 case SampleType::U8_BGR:
-                    process_ycbcr_8x8   = process_ycbcr_bgr_8x8_sse41;
-                    process_ycbcr_8x16  = process_ycbcr_bgr_8x16_sse41;
-                    process_ycbcr_16x8  = process_ycbcr_bgr_16x8_sse41;
-                    process_ycbcr_16x16 = process_ycbcr_bgr_16x16_sse41;
+                    BIND_YCBCR(8x8,   process_ycbcr_bgr_8x8_sse41);
+                    BIND_YCBCR(8x16,  process_ycbcr_bgr_8x16_sse41);
+                    BIND_YCBCR(16x8,  process_ycbcr_bgr_16x8_sse41);
+                    BIND_YCBCR(16x16, process_ycbcr_bgr_16x16_sse41);
                     simd_8x8   = "SSE4.1";
                     simd_8x16  = "SSE4.1";
                     simd_16x8  = "SSE4.1";
                     simd_16x16 = "SSE4.1";
+                    simd_16x16_shuffle = true;
                     break;
                 case SampleType::U8_RGB:
-                    process_ycbcr_8x8   = process_ycbcr_rgb_8x8_sse41;
-                    process_ycbcr_8x16  = process_ycbcr_rgb_8x16_sse41;
-                    process_ycbcr_16x8  = process_ycbcr_rgb_16x8_sse41;
-                    process_ycbcr_16x16 = process_ycbcr_rgb_16x16_sse41;
+                    BIND_YCBCR(8x8,   process_ycbcr_rgb_8x8_sse41);
+                    BIND_YCBCR(8x16,  process_ycbcr_rgb_8x16_sse41);
+                    BIND_YCBCR(16x8,  process_ycbcr_rgb_16x8_sse41);
+                    BIND_YCBCR(16x16, process_ycbcr_rgb_16x16_sse41);
                     simd_8x8   = "SSE4.1";
                     simd_8x16  = "SSE4.1";
                     simd_16x8  = "SSE4.1";
                     simd_16x16 = "SSE4.1";
+                    simd_16x16_shuffle = true;
                     break;
                 case SampleType::U8_BGRA:
                     break;
@@ -2798,7 +2809,7 @@ namespace mango::image::jpeg
                 case SampleType::U8_BGRA:
                     break;
                 case SampleType::U8_RGBA:
-                    process_ycbcr_8x8 = process_ycbcr_rgba_8x8_avx2;
+                    BIND_YCBCR(8x8, process_ycbcr_rgba_8x8_avx2);
                     simd_8x8   = "AVX2";
                     break;
             }
@@ -2807,6 +2818,12 @@ namespace mango::image::jpeg
 #endif // MANGO_ENABLE_AVX2
 
         std::string id;
+
+        processState.color = nullptr;
+        for (int i = 0; i < JPEG_MAX_BLOCKS_IN_MCU; ++i)
+        {
+            processState.idct_offset[i] = i * 64;
+        }
 
         // determine jpeg type -> select innerloops
         switch (m_components)
@@ -2828,6 +2845,7 @@ namespace mango::image::jpeg
                         if (process_ycbcr_8x8)
                         {
                             processState.process = process_ycbcr_8x8;
+                            processState.color = color_ycbcr_8x8;
                             id = fmt::format("YCbCr 8x8 {}", simd_8x8);
                         }
                     }
@@ -2837,6 +2855,7 @@ namespace mango::image::jpeg
                         if (process_ycbcr_8x16)
                         {
                             processState.process = process_ycbcr_8x16;
+                            processState.color = color_ycbcr_8x16;
                             id = fmt::format("YCbCr 8x16 {}", simd_8x16);
                         }
                     }
@@ -2846,6 +2865,7 @@ namespace mango::image::jpeg
                         if (process_ycbcr_16x8)
                         {
                             processState.process = process_ycbcr_16x8;
+                            processState.color = color_ycbcr_16x8;
                             id = fmt::format("YCbCr 16x8 {}", simd_16x8);
                         }
                     }
@@ -2855,7 +2875,15 @@ namespace mango::image::jpeg
                         if (process_ycbcr_16x16)
                         {
                             processState.process = process_ycbcr_16x16;
+                            processState.color = color_ycbcr_16x16;
                             id = fmt::format("YCbCr 16x16 {}", simd_16x16);
+
+                            if (simd_16x16_shuffle)
+                            {
+                                // Huffman Y0,Y1,Y2,Y3,Cb,Cr → spatial Y0,Y2,Y1,Y3,Cb,Cr
+                                processState.idct_offset[1] = 128;
+                                processState.idct_offset[2] = 64;
+                            }
                         }
                     }
                 }
@@ -2879,8 +2907,11 @@ namespace mango::image::jpeg
         if (m_rgb_colorspace || options.jpeg_colorspace_rgb)
         {
             processState.process = process_rgb;
+            processState.color = nullptr;
             id = "RGB";
         }
+
+#undef BIND_YCBCR
 
         m_ycbcr_name = id;
 
@@ -3275,7 +3306,8 @@ namespace mango::image::jpeg
             const size_t ystride = stride * yblock;
             const int N = 8;
 
-            AlignedStorage<s16> data(JPEG_MAX_SAMPLES_IN_MCU);
+            const int mcu_data_size = blocks_in_mcu * 64;
+            AlignedStorage<s16> data(JPEG_MCU_TILE * JPEG_MAX_SAMPLES_IN_MCU);
 
             u8* image = m_sink.surface->image;
 
@@ -3302,19 +3334,45 @@ namespace mango::image::jpeg
                     const int yblock_last = yclip ? yclip : yblock;
 
                     u8* dest = image + y * ystride;
+                    const int ysize = y == ymcu_last ? yblock_last : yblock;
+
+                    int n = 0;
+                    u8* span_dest = dest;
+
+                    auto flush = [&]()
+                    {
+                        if (n > 0)
+                        {
+                            process_span(span_dest, stride, data, n, xblock, ysize);
+                            span_dest += size_t(n) * xstride;
+                            n = 0;
+                        }
+                    };
 
                     for (int x = 0; x < xmcu; ++x)
                     {
-                        decodeState.decode(data, &decodeState);
+                        s16* slot = data + n * mcu_data_size;
+                        decodeState.decode(slot, &decodeState);
 
-                        int xsize = x == xmcu_last ? xblock_last : xblock;
-                        int ysize = y == ymcu_last ? yblock_last : yblock;
-
-                        process_and_clip(dest, stride, data, xsize, ysize);
-                        dest += xstride;
+                        const bool last_clipped = (x == xmcu_last && xblock_last != xblock);
+                        if (last_clipped)
+                        {
+                            flush();
+                            process_and_clip(span_dest, stride, slot, xblock_last, ysize);
+                            span_dest += xstride;
+                        }
+                        else
+                        {
+                            ++n;
+                            if (n == JPEG_MCU_TILE)
+                            {
+                                flush();
+                            }
+                        }
 
                         if (++restart_counter == restartInterval)
                         {
+                            flush();
                             decodeState.restart();
                             restart_counter = 0;
 
@@ -3334,6 +3392,8 @@ namespace mango::image::jpeg
                             decodeState.buffer.ptr = p;
                         }
                     }
+
+                    flush();
                 }
 
                 ImageDecodeRect rect;
@@ -3439,7 +3499,8 @@ namespace mango::image::jpeg
                 // enqueue task
                 queue.enqueue([=, this]
                 {
-                    AlignedStorage<s16> data(JPEG_MAX_SAMPLES_IN_MCU);
+                    AlignedStorage<s16> data(JPEG_MCU_TILE * JPEG_MAX_SAMPLES_IN_MCU);
+                    const int mcu_data_size = blocks_in_mcu * 64;
 
                     const u8* ptr = p;
 
@@ -3457,11 +3518,16 @@ namespace mango::image::jpeg
                         u8* dest = image + i * ystride;
                         const int height = (i == ymcu_last) ? yblock_last : yblock;
 
-                        for (int x = 0; x < xmcu_last; ++x)
+                        for (int x = 0; x < xmcu_last; )
                         {
-                            state.decode(data, &state);
-                            process_and_clip(dest, stride, data, xblock, height);
-                            dest += xstride;
+                            const int n = std::min(JPEG_MCU_TILE, xmcu_last - x);
+                            for (int k = 0; k < n; ++k)
+                            {
+                                state.decode(data + k * mcu_data_size, &state);
+                            }
+                            process_span(dest, stride, data, n, xblock, height);
+                            dest += size_t(n) * xstride;
+                            x += n;
                         }
 
                         // last column
@@ -3533,7 +3599,8 @@ namespace mango::image::jpeg
                 // enqueue task
                 queue.enqueue([=, this] (const u8* p_start)
                 {
-                    AlignedStorage<s16> data(JPEG_MAX_SAMPLES_IN_MCU);
+                    AlignedStorage<s16> data(JPEG_MCU_TILE * JPEG_MAX_SAMPLES_IN_MCU);
+                    const int mcu_data_size = blocks_in_mcu * 64;
                     const u8* p = p_start;
 
                     for (int y = y0; y < y1; ++y)
@@ -3549,11 +3616,16 @@ namespace mango::image::jpeg
                         u8* dest = image + y * ystride;
                         const int height = (y == ymcu_last) ? yblock_last : yblock;
 
-                        for (int x = 0; x < xmcu_last; ++x)
+                        for (int x = 0; x < xmcu_last; )
                         {
-                            state.decode(data, &state);
-                            process_and_clip(dest, stride, data, xblock, height);
-                            dest += xstride;
+                            const int n = std::min(JPEG_MCU_TILE, xmcu_last - x);
+                            for (int k = 0; k < n; ++k)
+                            {
+                                state.decode(data + k * mcu_data_size, &state);
+                            }
+                            process_span(dest, stride, data, n, xblock, height);
+                            dest += size_t(n) * xstride;
+                            x += n;
                         }
 
                         // last column
@@ -3945,17 +4017,13 @@ namespace mango::image::jpeg
             u8* dest = image + y * ystride;
             int ysize = y == ymcu_last ? yblock_last : yblock;
 
-            for (int x = 0; x < xmcu_last; ++x)
-            {
-                process_and_clip(dest, stride, data, xblock, ysize);
-                data += mcu_data_size;
-                dest += xstride;
-            }
+            process_span(dest, stride, data, xmcu_last, xblock, ysize);
+            data += xmcu_last * mcu_data_size;
+            dest += xmcu_last * xstride;
 
             // last column
             process_and_clip(dest, stride, data, xblock_last, ysize);
             data += mcu_data_size;
-            dest += xstride;
         }
 
         ImageDecodeRect rect;
@@ -3969,8 +4037,88 @@ namespace mango::image::jpeg
         blit_and_update(rect);
     }
 
+    void StreamDecoder::color_and_clip(u8* dest, size_t stride, const u8* spatial, int width, int height)
+    {
+        if (xblock != width || yblock != height)
+        {
+            u8 temp[JPEG_MAX_SAMPLES_IN_MCU * 4];
+
+            const int bytes_per_scan = width * m_sink.surface->format.bytes();
+            const int block_stride = xblock * 4;
+            u8* src = temp;
+
+            processState.color(temp, block_stride, spatial, &processState, width, height, 1, 0);
+
+            for (int y = 0; y < height; ++y)
+            {
+                std::memcpy(dest, src, bytes_per_scan);
+                src += block_stride;
+                dest += stride;
+            }
+        }
+        else
+        {
+            processState.color(dest, stride, spatial, &processState, width, height, 1, 0);
+        }
+    }
+
+    void StreamDecoder::process_span(u8* dest, size_t stride, const s16* data, int count, int width, int height)
+    {
+        const int mcu_data_size = blocks_in_mcu * 64;
+        const size_t xstride = m_sink.surface->format.bytes() * xblock;
+
+        if (!processState.color)
+        {
+            for (int i = 0; i < count; ++i)
+            {
+                process_and_clip(dest, stride, data, width, height);
+                data += mcu_data_size;
+                dest += xstride;
+            }
+            return;
+        }
+
+        alignas(64) u8 slab[JPEG_MCU_TILE * JPEG_MAX_SAMPLES_IN_MCU];
+
+        int remaining = count;
+        while (remaining > 0)
+        {
+            const int n = std::min(remaining, JPEG_MCU_TILE);
+
+            for (int i = 0; i < n; ++i)
+            {
+                processState.idctMCU(slab + i * JPEG_MAX_SAMPLES_IN_MCU, data + i * mcu_data_size);
+            }
+
+            if (width == xblock && height == yblock)
+            {
+                processState.color(dest, stride, slab, &processState, width, height, n, xstride);
+                dest += size_t(n) * xstride;
+            }
+            else
+            {
+                for (int i = 0; i < n; ++i)
+                {
+                    color_and_clip(dest, stride, slab + i * JPEG_MAX_SAMPLES_IN_MCU, width, height);
+                    dest += xstride;
+                }
+            }
+
+            data += n * mcu_data_size;
+            remaining -= n;
+        }
+    }
+
     void StreamDecoder::process_and_clip(u8* dest, size_t stride, const s16* data, int width, int height)
     {
+        if (processState.color)
+        {
+            alignas(64) u8 spatial[JPEG_MAX_SAMPLES_IN_MCU];
+            processState.idctMCU(spatial, data);
+            color_and_clip(dest, stride, spatial, width, height);
+            return;
+        }
+
         if (xblock != width || yblock != height)
         {
             u8 temp[JPEG_MAX_SAMPLES_IN_MCU * 4];

--- a/source/mango/jpeg/jpeg_decode.cpp
+++ b/source/mango/jpeg/jpeg_decode.cpp
@@ -1759,11 +1759,15 @@ namespace mango::image::jpeg
 
         if (components != processState.frames && !is_progressive)
         {
-            is_multiscan = true;
+            if (!is_multiscan)
+            {
+                is_multiscan = true;
 
-            // allocate blocks
-            size_t num_blocks = size_t(mcus) * blocks_in_mcu;
-            blockVector.resize(num_blocks * 64);
+                // allocate blocks (zeroed once; each SOS scan adds its components)
+                size_t num_blocks = size_t(mcus) * blocks_in_mcu;
+                blockVector.resize(num_blocks * 64);
+                std::memset(blockVector, 0, blockVector.size() * sizeof(s16));
+            }
         }
 
         decodeState.comps_in_scan = components;
@@ -2885,13 +2889,15 @@ namespace mango::image::jpeg
                 break;
 
             case 4:
-                if (getCmykIcc().size)
+                if (getCmykIcc().size && processState.colorspace == ColorSpace::CMYK)
                 {
+                    // Raw CMYK + ICC: store plates, invert Adobe encoding, LittleCMS to sRGB.
                     processState.color = process_cmyk_store_rgba;
                     m_cmyk_store_mode = true;
                 }
                 else
                 {
+                    // YCCK (and CMYK without ICC): convert in the MCU kernel.
                     processState.color = color_cmyk;
                     m_cmyk_store_mode = false;
                 }
@@ -2930,9 +2936,10 @@ namespace mango::image::jpeg
         // determine if we need a full-surface temporary storage
         if (is_progressive || is_multiscan)
         {
-            // allocate blocks
+            // allocate blocks (zeroed: multiscan fills components across separate SOS scans)
             size_t num_blocks = size_t(mcus) * blocks_in_mcu;
             blockVector.resize(num_blocks * 64);
+            std::memset(blockVector, 0, blockVector.size() * sizeof(s16));
         }
 
         // find best matching format
@@ -2944,9 +2951,9 @@ namespace mango::image::jpeg
         // configure multithreading
         m_hardware_concurrency = int(options.multithread ? ThreadPool::getHardwareConcurrency() : 1);
 
-        if (m_components == 4 && getCmykIcc().size)
+        if (m_components == 4)
         {
-            // CMYK ICC path stores plates in the surface before a single-pass color transform.
+            // CMYK / YCCK is the slow path; keep entropy + finish serial for correctness.
             m_hardware_concurrency = 1;
         }
 
@@ -3001,12 +3008,26 @@ namespace mango::image::jpeg
             m_sink.surface = temp.get();
         }
 
+        // ICC CMYK stores raw plates during MCU assembly; band callbacks would upload
+        // pre-transform data (ifap tiles) and leave a mix of wrong/correct pixels.
+        ImageDecodeCallback saved_callback;
+        const bool suppress_cmyk_callbacks = m_cmyk_store_mode && m_interface;
+        if (suppress_cmyk_callbacks)
+        {
+            saved_callback = m_interface->callback;
+            m_interface->callback = nullptr;
+        }
+
         // decoding
         parse(scan_memory, true);
 
         if (!header)
         {
             blockVector.resize(0);
+            if (suppress_cmyk_callbacks)
+            {
+                m_interface->callback = saved_callback;
+            }
             m_decode_status.setError(header.info);
             return m_decode_status;
         }
@@ -3014,6 +3035,10 @@ namespace mango::image::jpeg
         if (m_interface->cancelled)
         {
             blockVector.resize(0);
+            if (suppress_cmyk_callbacks)
+            {
+                m_interface->callback = saved_callback;
+            }
             m_decode_status.info = getInfo();
             return m_decode_status;
         }
@@ -3036,7 +3061,7 @@ namespace mango::image::jpeg
                 ? Surface(*m_sink.surface, 0, 0, m_width, m_height)
                 : Surface(*m_sink.surface, 0, 0, m_width, m_height);
 
-            if (profile.size && transform_cmyk_surface_to_srgb(surface, profile))
+            if (profile.size && transform_cmyk_surface_to_srgb(surface, profile, processState.colorspace == ColorSpace::CMYK))
             {
                 m_cmyk_icc_applied = true;
                 icc_buffer.reset();
@@ -3055,6 +3080,26 @@ namespace mango::image::jpeg
                 {
                     m_sink.target->blit(0, 0, surface);
                 }
+            }
+        }
+
+        if (suppress_cmyk_callbacks)
+        {
+            m_interface->callback = saved_callback;
+
+            // Async decoders rely on band callbacks; ICC CMYK suppressed them during
+            // assembly. ImageDecoder::launch() does not dispatch when async=true.
+            if (saved_callback && !m_interface->cancelled)
+            {
+                ImageDecodeRect rect;
+
+                rect.x = 0;
+                rect.y = 0;
+                rect.width = m_width;
+                rect.height = m_height;
+                rect.progress = 1.0f;
+
+                m_interface->clipAndDispatch(*m_sink.target, rect);
             }
         }
 

--- a/source/mango/jpeg/jpeg_idct.cpp
+++ b/source/mango/jpeg/jpeg_idct.cpp
@@ -799,6 +799,17 @@ namespace mango::image::jpeg
 
 #if defined(MANGO_ENABLE_AVX512)
 
+    #define transpose4x128(s0, s1, s2, s3) do { \
+        __m512i t0 = _mm512_shuffle_i32x4(s0, s1, 0x44); \
+        __m512i t1 = _mm512_shuffle_i32x4(s0, s1, 0xEE); \
+        __m512i t2 = _mm512_shuffle_i32x4(s2, s3, 0x44); \
+        __m512i t3 = _mm512_shuffle_i32x4(s2, s3, 0xEE); \
+        s0 = _mm512_shuffle_i32x4(t0, t2, 0x88); \
+        s1 = _mm512_shuffle_i32x4(t0, t2, 0xDD); \
+        s2 = _mm512_shuffle_i32x4(t1, t3, 0x88); \
+        s3 = _mm512_shuffle_i32x4(t1, t3, 0xDD); \
+    } while (0)
+
     // Linear quad 8x8 iDCT: consecutive blocks in 128-bit lanes, fused dequant.
     void idct_avx512(u8* dest, const s16* src, const s16* const* qt, int blocks, int idx, int count)
     {
@@ -813,34 +824,46 @@ namespace mango::image::jpeg
         const __m512i round_inv_col = _mm512_set1_epi16(16 + bias);
         const __m512i round_inv_corr = _mm512_sub_epi16(round_inv_col, one);
 
-        auto load4 = [](const __m128i* a, const __m128i* b, const __m128i* c, const __m128i* d, int i) -> __m512i
-        {
-            return _mm512_inserti32x4(
-                _mm512_inserti32x4(
-                    _mm512_inserti32x4(_mm512_castsi128_si512(a[i]), b[i], 1),
-                    c[i], 2),
-                d[i], 3);
-        };
-
         for (int n = 0; n < count; n += 4)
         {
-            const __m128i* data0 = reinterpret_cast<const __m128i *>(src + 0);
-            const __m128i* data1 = reinterpret_cast<const __m128i *>(src + 64);
-            const __m128i* data2 = reinterpret_cast<const __m128i *>(src + 128);
-            const __m128i* data3 = reinterpret_cast<const __m128i *>(src + 192);
-            const __m128i* q0 = reinterpret_cast<const __m128i *>(qt[idx + 0]);
-            const __m128i* q1 = reinterpret_cast<const __m128i *>(qt[idx + 1]);
-            const __m128i* q2 = reinterpret_cast<const __m128i *>(qt[idx + 2]);
-            const __m128i* q3 = reinterpret_cast<const __m128i *>(qt[idx + 3]);
+            const s16* qtable0 = qt[idx + 0];
+            const s16* qtable1 = qt[idx + 1];
+            const s16* qtable2 = qt[idx + 2];
+            const s16* qtable3 = qt[idx + 3];
 
-            __m512i v0 = _mm512_mullo_epi16(load4(data0, data1, data2, data3, 0), load4(q0, q1, q2, q3, 0));
-            __m512i v1 = _mm512_mullo_epi16(load4(data0, data1, data2, data3, 1), load4(q0, q1, q2, q3, 1));
-            __m512i v2 = _mm512_mullo_epi16(load4(data0, data1, data2, data3, 2), load4(q0, q1, q2, q3, 2));
-            __m512i v3 = _mm512_mullo_epi16(load4(data0, data1, data2, data3, 3), load4(q0, q1, q2, q3, 3));
-            __m512i v4 = _mm512_mullo_epi16(load4(data0, data1, data2, data3, 4), load4(q0, q1, q2, q3, 4));
-            __m512i v5 = _mm512_mullo_epi16(load4(data0, data1, data2, data3, 5), load4(q0, q1, q2, q3, 5));
-            __m512i v6 = _mm512_mullo_epi16(load4(data0, data1, data2, data3, 6), load4(q0, q1, q2, q3, 6));
-            __m512i v7 = _mm512_mullo_epi16(load4(data0, data1, data2, data3, 7), load4(q0, q1, q2, q3, 7));
+            __m512i s0 = _mm512_loadu_si512(src + 0);
+            __m512i s1 = _mm512_loadu_si512(src + 64);
+            __m512i s2 = _mm512_loadu_si512(src + 128);
+            __m512i s3 = _mm512_loadu_si512(src + 192);
+            transpose4x128(s0, s1, s2, s3);
+
+            __m512i q0 = _mm512_loadu_si512(qtable0 + 0);
+            __m512i q1 = _mm512_loadu_si512(qtable1 + 0);
+            __m512i q2 = _mm512_loadu_si512(qtable2 + 0);
+            __m512i q3 = _mm512_loadu_si512(qtable3 + 0);
+            transpose4x128(q0, q1, q2, q3);
+
+            __m512i v0 = _mm512_mullo_epi16(s0, q0);
+            __m512i v1 = _mm512_mullo_epi16(s1, q1);
+            __m512i v2 = _mm512_mullo_epi16(s2, q2);
+            __m512i v3 = _mm512_mullo_epi16(s3, q3);
+
+            __m512i s4 = _mm512_loadu_si512(src + 32);
+            __m512i s5 = _mm512_loadu_si512(src + 96);
+            __m512i s6 = _mm512_loadu_si512(src + 160);
+            __m512i s7 = _mm512_loadu_si512(src + 224);
+            transpose4x128(s4, s5, s6, s7);
+
+            __m512i q4 = _mm512_loadu_si512(qtable0 + 32);
+            __m512i q5 = _mm512_loadu_si512(qtable1 + 32);
+            __m512i q6 = _mm512_loadu_si512(qtable2 + 32);
+            __m512i q7 = _mm512_loadu_si512(qtable3 + 32);
+            transpose4x128(q4, q5, q6, q7);
+
+            __m512i v4 = _mm512_mullo_epi16(s4, q4);
+            __m512i v5 = _mm512_mullo_epi16(s5, q5);
+            __m512i v6 = _mm512_mullo_epi16(s6, q6);
+            __m512i v7 = _mm512_mullo_epi16(s7, q7);
 
             __m512i r_xmm0, r_xmm1, r_xmm2, r_xmm3, r_xmm4, r_xmm5, r_xmm6, r_xmm7;
             __m512i row0, row1, row2, row3, row4, row5, row6, row7;
@@ -1081,67 +1104,17 @@ namespace mango::image::jpeg
             r6 = _mm512_srai_epi16(r6, 5);
             r7 = _mm512_srai_epi16(r7, 5);
 
-            __m512i s0 = _mm512_packus_epi16(r0, r1);
-            __m512i s1 = _mm512_packus_epi16(r2, r3);
-            __m512i s2 = _mm512_packus_epi16(r4, r5);
-            __m512i s3 = _mm512_packus_epi16(r6, r7);
+            __m512i c0 = _mm512_packus_epi16(r0, r1);
+            __m512i c1 = _mm512_packus_epi16(r2, r3);
+            __m512i c2 = _mm512_packus_epi16(r4, r5);
+            __m512i c3 = _mm512_packus_epi16(r6, r7);
+            transpose4x128(c0, c1, c2, c3);
 
-            /*
-            auto store4 = [&](__m512i s, int i)
-            {
-                _mm_storeu_si128(reinterpret_cast<__m128i *>(dest +   0) + i, _mm512_extracti32x4_epi32(s, 0));
-                _mm_storeu_si128(reinterpret_cast<__m128i *>(dest +  64) + i, _mm512_extracti32x4_epi32(s, 1));
-                _mm_storeu_si128(reinterpret_cast<__m128i *>(dest + 128) + i, _mm512_extracti32x4_epi32(s, 2));
-                _mm_storeu_si128(reinterpret_cast<__m128i *>(dest + 192) + i, _mm512_extracti32x4_epi32(s, 3));
-            };
-
-            store4(s0, 0);
-            store4(s1, 1);
-            store4(s2, 2);
-            store4(s3, 3);
-
-            __m512i s0 = _mm512_packus_epi16(r0, r1);
-            __m512i s1 = _mm512_packus_epi16(r2, r3);
-            __m512i s2 = _mm512_packus_epi16(r4, r5);
-            __m512i s3 = _mm512_packus_epi16(r6, r7);
-            */
-
-            /*
-            auto pack4 = [] (__m512i a, __m512i b, __m512i c, __m512i d, int lane)
-            {
-                __m128i x0 = _mm512_extracti32x4_epi32(a, lane);
-                __m128i x1 = _mm512_extracti32x4_epi32(b, lane);
-                __m128i x2 = _mm512_extracti32x4_epi32(c, lane);
-                __m128i x3 = _mm512_extracti32x4_epi32(d, lane);
-                __m512i r = _mm512_castsi128_si512(x0);
-                r = _mm512_inserti32x4(r, x1, 1);
-                r = _mm512_inserti32x4(r, x2, 2);
-                r = _mm512_inserti32x4(r, x3, 3);
-                return r;
-            };
-
-            __m512i* d = reinterpret_cast<__m512i*>(dest);
-            d[0] = pack4(s0, s1, s2, s3, 0);
-            d[1] = pack4(s0, s1, s2, s3, 1);
-            d[2] = pack4(s0, s1, s2, s3, 2);
-            d[3] = pack4(s0, s1, s2, s3, 3);
-            */
-
-            // s0 = A0 A1 A2 A3, s1 = B0 B1 B2 B3, ...
-            __m512i t0 = _mm512_shuffle_i32x4(s0, s1, 0x44); // A0 A1 B0 B1
-            __m512i t1 = _mm512_shuffle_i32x4(s0, s1, 0xEE); // A2 A3 B2 B3
-            __m512i t2 = _mm512_shuffle_i32x4(s2, s3, 0x44); // C0 C1 D0 D1
-            __m512i t3 = _mm512_shuffle_i32x4(s2, s3, 0xEE); // C2 C3 D2 D3
-
-            __m512i d0 = _mm512_shuffle_i32x4(t0, t2, 0x88); // A0 B0 C0 D0
-            __m512i d1 = _mm512_shuffle_i32x4(t0, t2, 0xDD); // A1 B1 C1 D1
-            __m512i d2 = _mm512_shuffle_i32x4(t1, t3, 0x88); // A2 B2 C2 D2
-            __m512i d3 = _mm512_shuffle_i32x4(t1, t3, 0xDD); // A3 B3 C3 D3
-
-            _mm512_storeu_si512(dest +   0, d0);
-            _mm512_storeu_si512(dest +  64, d1);
-            _mm512_storeu_si512(dest + 128, d2);
-            _mm512_storeu_si512(dest + 192, d3);
+            // store
+            _mm512_storeu_si512(dest +   0, c0);
+            _mm512_storeu_si512(dest +  64, c1);
+            _mm512_storeu_si512(dest + 128, c2);
+            _mm512_storeu_si512(dest + 192, c3);
 
             dest += 256;
             src += 256;

--- a/source/mango/jpeg/jpeg_idct.cpp
+++ b/source/mango/jpeg/jpeg_idct.cpp
@@ -778,6 +778,315 @@ namespace mango::image::jpeg
 
 #endif // MANGO_ENABLE_AVX2
 
+#if defined(MANGO_ENABLE_AVX512)
+
+    // Quad 8x8 iDCT: blocks A,B,C,D in the four 128-bit lanes of a ZMM.
+    // All four blocks share the same quantization table (same block index in adjacent MCUs).
+    void idct_avx512(u8* dest0, u8* dest1, u8* dest2, u8* dest3,
+                     const s16* src0, const s16* src1, const s16* src2, const s16* src3, const s16* qt)
+    {
+        const __m128i* data0 = reinterpret_cast<const __m128i *>(src0);
+        const __m128i* data1 = reinterpret_cast<const __m128i *>(src1);
+        const __m128i* data2 = reinterpret_cast<const __m128i *>(src2);
+        const __m128i* data3 = reinterpret_cast<const __m128i *>(src3);
+        const __m128i* qtable = reinterpret_cast<const __m128i *>(qt);
+
+        auto load4 = [&](int i) -> __m512i
+        {
+            return _mm512_inserti32x4(
+                _mm512_inserti32x4(
+                    _mm512_inserti32x4(_mm512_castsi128_si512(data0[i]), data1[i], 1),
+                    data2[i], 2),
+                data3[i], 3);
+        };
+
+        __m512i v0 = _mm512_mullo_epi16(load4(0), _mm512_broadcast_i32x4(qtable[0]));
+        __m512i v1 = _mm512_mullo_epi16(load4(1), _mm512_broadcast_i32x4(qtable[1]));
+        __m512i v2 = _mm512_mullo_epi16(load4(2), _mm512_broadcast_i32x4(qtable[2]));
+        __m512i v3 = _mm512_mullo_epi16(load4(3), _mm512_broadcast_i32x4(qtable[3]));
+        __m512i v4 = _mm512_mullo_epi16(load4(4), _mm512_broadcast_i32x4(qtable[4]));
+        __m512i v5 = _mm512_mullo_epi16(load4(5), _mm512_broadcast_i32x4(qtable[5]));
+        __m512i v6 = _mm512_mullo_epi16(load4(6), _mm512_broadcast_i32x4(qtable[6]));
+        __m512i v7 = _mm512_mullo_epi16(load4(7), _mm512_broadcast_i32x4(qtable[7]));
+
+        __m512i r_xmm0, r_xmm1, r_xmm2, r_xmm3, r_xmm4, r_xmm5, r_xmm6, r_xmm7;
+        __m512i row0, row1, row2, row3, row4, row5, row6, row7;
+
+        // row 1 and Row 3
+
+        const __m128i* table04 = reinterpret_cast<const __m128i*>(shortM128_tab_i_04);
+        const __m128i* table26 = reinterpret_cast<const __m128i*>(shortM128_tab_i_26);
+
+        r_xmm0 = _mm512_shufflelo_epi16(v0, 0xd8);
+        r_xmm1 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x00));
+        r_xmm1 = _mm512_madd_epi16(r_xmm1, _mm512_broadcast_i32x4(table04[0]));
+        r_xmm3 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x55));
+        r_xmm0 = _mm512_shufflehi_epi16(r_xmm0, 0xd8);
+        r_xmm3 = _mm512_madd_epi16(r_xmm3, _mm512_broadcast_i32x4(table04[2]));
+        r_xmm2 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xaa));
+        r_xmm0 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xff));
+        r_xmm2 = _mm512_madd_epi16(r_xmm2, _mm512_broadcast_i32x4(table04[1]));
+
+        const __m512i round_inv_row = _mm512_set1_epi32(2048);
+
+        r_xmm4 = _mm512_shufflehi_epi16(v2, 0xd8);
+        r_xmm1 = _mm512_add_epi32(r_xmm1, round_inv_row);
+        r_xmm4 = _mm512_shufflelo_epi16(r_xmm4, 0xd8);
+        r_xmm0 = _mm512_madd_epi16(r_xmm0, _mm512_broadcast_i32x4(table04[3]));
+        r_xmm5 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x00));
+        r_xmm6 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xaa));
+        r_xmm5 = _mm512_madd_epi16(r_xmm5, _mm512_broadcast_i32x4(table26[0]));
+        r_xmm1 = _mm512_add_epi32(r_xmm1, r_xmm2);
+        r_xmm7 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x55));
+        r_xmm6 = _mm512_madd_epi16(r_xmm6, _mm512_broadcast_i32x4(table26[1]));
+        r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm3);
+        r_xmm4 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xff));
+        r_xmm2 = _mm512_sub_epi32(r_xmm1, r_xmm0);
+        r_xmm7 = _mm512_madd_epi16(r_xmm7, _mm512_broadcast_i32x4(table26[2]));
+        r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm1);
+        r_xmm2 = _mm512_srai_epi32(r_xmm2, 12);
+        r_xmm5 = _mm512_add_epi32(r_xmm5, round_inv_row);
+        r_xmm4 = _mm512_madd_epi16(r_xmm4, _mm512_broadcast_i32x4(table26[3]));
+        r_xmm5 = _mm512_add_epi32(r_xmm5, r_xmm6);
+        r_xmm0 = _mm512_srai_epi32(r_xmm0, 12);
+        r_xmm2 = _mm512_shuffle_epi32(r_xmm2, (_MM_PERM_ENUM)(0x1b));
+        row0 = _mm512_packs_epi32(r_xmm0, r_xmm2);
+
+        r_xmm4 = _mm512_add_epi32(r_xmm4, r_xmm7);
+        r_xmm6 = _mm512_sub_epi32(r_xmm5, r_xmm4);
+        r_xmm4 = _mm512_add_epi32(r_xmm4, r_xmm5);
+        r_xmm6 = _mm512_srai_epi32(r_xmm6, 12);
+        r_xmm4 = _mm512_srai_epi32(r_xmm4, 12);
+        r_xmm6 = _mm512_shuffle_epi32(r_xmm6, (_MM_PERM_ENUM)(0x1b));
+        row2 = _mm512_packs_epi32(r_xmm4, r_xmm6);
+
+        // row 5 and row 7
+
+        r_xmm0 = _mm512_shufflelo_epi16(v4, 0xd8);
+        r_xmm1 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x00));
+        r_xmm1 = _mm512_madd_epi16(r_xmm1, _mm512_broadcast_i32x4(table04[0]));
+        r_xmm3 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x55));
+        r_xmm0 = _mm512_shufflehi_epi16(r_xmm0, 0xd8);
+        r_xmm3 = _mm512_madd_epi16(r_xmm3, _mm512_broadcast_i32x4(table04[2]));
+        r_xmm2 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xaa));
+        r_xmm0 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xff));
+        r_xmm2 = _mm512_madd_epi16(r_xmm2, _mm512_broadcast_i32x4(table04[1]));
+        r_xmm4 = _mm512_shufflehi_epi16(v6, 0xd8);
+        r_xmm1 = _mm512_add_epi32(r_xmm1, round_inv_row);
+        r_xmm4 = _mm512_shufflelo_epi16(r_xmm4, 0xd8);
+        r_xmm0 = _mm512_madd_epi16(r_xmm0, _mm512_broadcast_i32x4(table04[3]));
+        r_xmm5 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x00));
+        r_xmm6 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xaa));
+        r_xmm5 = _mm512_madd_epi16(r_xmm5, _mm512_broadcast_i32x4(table26[0]));
+        r_xmm1 = _mm512_add_epi32(r_xmm1, r_xmm2);
+        r_xmm7 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x55));
+        r_xmm6 = _mm512_madd_epi16(r_xmm6, _mm512_broadcast_i32x4(table26[1]));
+        r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm3);
+        r_xmm4 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xff));
+        r_xmm2 = _mm512_sub_epi32(r_xmm1, r_xmm0);
+        r_xmm7 = _mm512_madd_epi16(r_xmm7, _mm512_broadcast_i32x4(table26[2]));
+        r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm1);
+        r_xmm2 = _mm512_srai_epi32(r_xmm2, 12);
+        r_xmm5 = _mm512_add_epi32(r_xmm5, round_inv_row);
+        r_xmm4 = _mm512_madd_epi16(r_xmm4, _mm512_broadcast_i32x4(table26[3]));
+        r_xmm5 = _mm512_add_epi32(r_xmm5, r_xmm6);
+        r_xmm0 = _mm512_srai_epi32(r_xmm0, 12);
+        r_xmm2 = _mm512_shuffle_epi32(r_xmm2, (_MM_PERM_ENUM)(0x1b));
+        row4 = _mm512_packs_epi32(r_xmm0, r_xmm2);
+
+        r_xmm4 = _mm512_add_epi32(r_xmm4, r_xmm7);
+        r_xmm6 = _mm512_sub_epi32(r_xmm5, r_xmm4);
+        r_xmm4 = _mm512_add_epi32(r_xmm4, r_xmm5);
+        r_xmm6 = _mm512_srai_epi32(r_xmm6, 12);
+        r_xmm4 = _mm512_srai_epi32(r_xmm4, 12);
+        r_xmm6 = _mm512_shuffle_epi32(r_xmm6, (_MM_PERM_ENUM)(0x1b));
+        row6 = _mm512_packs_epi32(r_xmm4, r_xmm6);
+
+        // row 4 and row 2
+
+        const __m128i* table35 = reinterpret_cast<const __m128i*>(shortM128_tab_i_35);
+        const __m128i* table17 = reinterpret_cast<const __m128i*>(shortM128_tab_i_17);
+
+        r_xmm0 = _mm512_shufflelo_epi16(v3, 0xd8);
+        r_xmm1 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x00));
+        r_xmm1 = _mm512_madd_epi16(r_xmm1, _mm512_broadcast_i32x4(table35[0]));
+        r_xmm3 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x55));
+        r_xmm0 = _mm512_shufflehi_epi16(r_xmm0, 0xd8);
+        r_xmm3 = _mm512_madd_epi16(r_xmm3, _mm512_broadcast_i32x4(table35[2]));
+        r_xmm2 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xaa));
+        r_xmm0 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xff));
+        r_xmm2 = _mm512_madd_epi16(r_xmm2, _mm512_broadcast_i32x4(table35[1]));
+        r_xmm4 = _mm512_shufflehi_epi16(v1, 0xd8);
+        r_xmm1 = _mm512_add_epi32(r_xmm1, round_inv_row);
+        r_xmm4 = _mm512_shufflelo_epi16(r_xmm4, 0xd8);
+        r_xmm0 = _mm512_madd_epi16(r_xmm0, _mm512_broadcast_i32x4(table35[3]));
+        r_xmm5 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x00));
+        r_xmm6 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xaa));
+        r_xmm5 = _mm512_madd_epi16(r_xmm5, _mm512_broadcast_i32x4(table17[0]));
+        r_xmm1 = _mm512_add_epi32(r_xmm1, r_xmm2);
+        r_xmm7 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x55));
+        r_xmm6 = _mm512_madd_epi16(r_xmm6, _mm512_broadcast_i32x4(table17[1]));
+        r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm3);
+        r_xmm4 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xff));
+        r_xmm2 = _mm512_sub_epi32(r_xmm1, r_xmm0);
+        r_xmm7 = _mm512_madd_epi16(r_xmm7, _mm512_broadcast_i32x4(table17[2]));
+        r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm1);
+        r_xmm2 = _mm512_srai_epi32(r_xmm2, 12);
+        r_xmm5 = _mm512_add_epi32(r_xmm5, round_inv_row);
+        r_xmm4 = _mm512_madd_epi16(r_xmm4, _mm512_broadcast_i32x4(table17[3]));
+        r_xmm5 = _mm512_add_epi32(r_xmm5, r_xmm6);
+        r_xmm0 = _mm512_srai_epi32(r_xmm0, 12);
+        r_xmm2 = _mm512_shuffle_epi32(r_xmm2, (_MM_PERM_ENUM)(0x1b));
+        row3 = _mm512_packs_epi32(r_xmm0, r_xmm2);
+
+        r_xmm4 = _mm512_add_epi32(r_xmm4, r_xmm7);
+        r_xmm6 = _mm512_sub_epi32(r_xmm5, r_xmm4);
+        r_xmm4 = _mm512_add_epi32(r_xmm5, r_xmm4);
+        r_xmm6 = _mm512_srai_epi32(r_xmm6, 12);
+        r_xmm4 = _mm512_srai_epi32(r_xmm4, 12);
+        r_xmm6 = _mm512_shuffle_epi32(r_xmm6, (_MM_PERM_ENUM)(0x1b));
+        row1 = _mm512_packs_epi32(r_xmm4, r_xmm6);
+
+        // row 6 and row 8
+
+        r_xmm0 = _mm512_shufflelo_epi16(v5, 0xd8);
+        r_xmm1 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x00));
+        r_xmm1 = _mm512_madd_epi16(r_xmm1, _mm512_broadcast_i32x4(table35[0]));
+        r_xmm3 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x55));
+        r_xmm0 = _mm512_shufflehi_epi16(r_xmm0, 0xd8);
+        r_xmm3 = _mm512_madd_epi16(r_xmm3, _mm512_broadcast_i32x4(table35[2]));
+        r_xmm2 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xaa));
+        r_xmm0 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xff));
+        r_xmm2 = _mm512_madd_epi16(r_xmm2, _mm512_broadcast_i32x4(table35[1]));
+        r_xmm4 = _mm512_shufflehi_epi16(v7, 0xd8);
+        r_xmm1 = _mm512_add_epi32(r_xmm1, round_inv_row);
+        r_xmm4 = _mm512_shufflelo_epi16(r_xmm4, 0xd8);
+        r_xmm0 = _mm512_madd_epi16(r_xmm0, _mm512_broadcast_i32x4(table35[3]));
+        r_xmm5 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x00));
+        r_xmm6 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xaa));
+        r_xmm5 = _mm512_madd_epi16(r_xmm5, _mm512_broadcast_i32x4(table17[0]));
+        r_xmm1 = _mm512_add_epi32(r_xmm1, r_xmm2);
+        r_xmm7 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x55));
+        r_xmm6 = _mm512_madd_epi16(r_xmm6, _mm512_broadcast_i32x4(table17[1]));
+        r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm3);
+        r_xmm4 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xff));
+        r_xmm2 = _mm512_sub_epi32(r_xmm1, r_xmm0);
+        r_xmm7 = _mm512_madd_epi16(r_xmm7, _mm512_broadcast_i32x4(table17[2]));
+        r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm1);
+        r_xmm2 = _mm512_srai_epi32(r_xmm2, 12);
+        r_xmm5 = _mm512_add_epi32(r_xmm5, round_inv_row);
+        r_xmm4 = _mm512_madd_epi16(r_xmm4, _mm512_broadcast_i32x4(table17[3]));
+        r_xmm5 = _mm512_add_epi32(r_xmm5, r_xmm6);
+        r_xmm0 = _mm512_srai_epi32(r_xmm0, 12);
+        r_xmm2 = _mm512_shuffle_epi32(r_xmm2, (_MM_PERM_ENUM)(0x1b));
+        row5 = _mm512_packs_epi32(r_xmm0, r_xmm2);
+
+        r_xmm4 = _mm512_add_epi32(r_xmm4, r_xmm7);
+        r_xmm6 = _mm512_sub_epi32(r_xmm5, r_xmm4);
+        r_xmm4 = _mm512_add_epi32(r_xmm5, r_xmm4);
+        r_xmm6 = _mm512_srai_epi32(r_xmm6, 12);
+        r_xmm4 = _mm512_srai_epi32(r_xmm4, 12);
+        r_xmm6 = _mm512_shuffle_epi32(r_xmm6, (_MM_PERM_ENUM)(0x1b));
+        row7 = _mm512_packs_epi32(r_xmm4, r_xmm6);
+
+        const __m512i tg = _mm512_broadcast_i32x4(_mm_set_epi16(-19195, -19195, -21746, -21746, 27146, 27146, 13036, 13036));
+        const __m512i one = _mm512_set1_epi16(1);
+
+        r_xmm1 = _mm512_shuffle_epi32(tg, (_MM_PERM_ENUM)(0xaa));
+        r_xmm0 = _mm512_mulhi_epi16(r_xmm1, row5);
+        r_xmm1 = _mm512_mulhi_epi16(r_xmm1, row3);
+        r_xmm5 = _mm512_shuffle_epi32(tg, (_MM_PERM_ENUM)(0x00));
+        r_xmm4 = _mm512_mulhi_epi16(r_xmm5, row7);
+        r_xmm5 = _mm512_mulhi_epi16(r_xmm5, row1);
+        r_xmm0 = _mm512_adds_epi16(r_xmm0, row5);
+        r_xmm1 = _mm512_adds_epi16(r_xmm1, row3);
+        r_xmm0 = _mm512_adds_epi16(r_xmm0, row3);
+        r_xmm3 = _mm512_shuffle_epi32(tg, (_MM_PERM_ENUM)(0x55));
+        r_xmm7 = _mm512_mulhi_epi16(r_xmm3, row6);
+        r_xmm3 = _mm512_mulhi_epi16(r_xmm3, row2);
+        r_xmm5 = _mm512_subs_epi16(r_xmm5, row7);
+        r_xmm4 = _mm512_adds_epi16(r_xmm4, row1);
+        r_xmm2 = _mm512_subs_epi16(r_xmm2, r_xmm1);
+        r_xmm1 = _mm512_adds_epi16(r_xmm0, r_xmm4);
+        r_xmm1 = _mm512_adds_epi16(r_xmm1, one);
+        r_xmm4 = _mm512_subs_epi16(r_xmm4, r_xmm0);
+        r_xmm6 = _mm512_adds_epi16(r_xmm5, r_xmm2);
+        r_xmm5 = _mm512_subs_epi16(r_xmm5, r_xmm2);
+        r_xmm5 = _mm512_adds_epi16(r_xmm5, one);
+
+        __m512i temp7 = r_xmm1;
+        __m512i temp3 = r_xmm6;
+
+        r_xmm0 = _mm512_shuffle_epi32(tg, (_MM_PERM_ENUM)(0xff));
+        r_xmm1 = _mm512_subs_epi16(r_xmm4, r_xmm5);
+        r_xmm4 = _mm512_adds_epi16(r_xmm4, r_xmm5);
+        r_xmm2 = _mm512_mulhi_epi16(r_xmm0, r_xmm4);
+        r_xmm7 = _mm512_adds_epi16(r_xmm7, row2);
+        r_xmm3 = _mm512_subs_epi16(r_xmm3, row6);
+        r_xmm0 = _mm512_mulhi_epi16(r_xmm0, r_xmm1);
+        r_xmm0 = _mm512_adds_epi16(r_xmm0, r_xmm1);
+        r_xmm5 = _mm512_adds_epi16(row0, row4);
+        r_xmm6 = _mm512_subs_epi16(row0, row4);
+        r_xmm4 = _mm512_adds_epi16(r_xmm4, r_xmm2);
+
+        r_xmm4 = _mm512_or_si512(r_xmm4, one);
+        r_xmm0 = _mm512_or_si512(r_xmm0, one);
+
+        const s16 bias = 128 << 5;
+        const __m512i round_inv_col = _mm512_set1_epi16(16 + bias);
+        const __m512i round_inv_corr = _mm512_sub_epi16(round_inv_col, one);
+
+        r_xmm1 = _mm512_subs_epi16(r_xmm6, r_xmm3);
+        r_xmm1 = _mm512_adds_epi16(r_xmm1, round_inv_corr);
+        r_xmm2 = _mm512_subs_epi16(r_xmm5, r_xmm7);
+        r_xmm2 = _mm512_adds_epi16(r_xmm2, round_inv_corr);
+        r_xmm5 = _mm512_adds_epi16(r_xmm5, r_xmm7);
+        r_xmm5 = _mm512_adds_epi16(r_xmm5, round_inv_col);
+        r_xmm6 = _mm512_adds_epi16(r_xmm6, r_xmm3);
+        r_xmm6 = _mm512_adds_epi16(r_xmm6, round_inv_col);
+
+        __m512i r0 = _mm512_adds_epi16(r_xmm5, temp7);
+        __m512i r1 = _mm512_adds_epi16(r_xmm6, r_xmm4);
+        __m512i r2 = _mm512_adds_epi16(r_xmm1, r_xmm0);
+        __m512i r3 = _mm512_adds_epi16(r_xmm2, temp3);
+        __m512i r4 = _mm512_subs_epi16(r_xmm2, temp3);
+        __m512i r5 = _mm512_subs_epi16(r_xmm1, r_xmm0);
+        __m512i r6 = _mm512_subs_epi16(r_xmm6, r_xmm4);
+        __m512i r7 = _mm512_subs_epi16(r_xmm5, temp7);
+
+        r0 = _mm512_srai_epi16(r0, 5);
+        r1 = _mm512_srai_epi16(r1, 5);
+        r2 = _mm512_srai_epi16(r2, 5);
+        r3 = _mm512_srai_epi16(r3, 5);
+        r4 = _mm512_srai_epi16(r4, 5);
+        r5 = _mm512_srai_epi16(r5, 5);
+        r6 = _mm512_srai_epi16(r6, 5);
+        r7 = _mm512_srai_epi16(r7, 5);
+
+        __m512i s0 = _mm512_packus_epi16(r0, r1);
+        __m512i s1 = _mm512_packus_epi16(r2, r3);
+        __m512i s2 = _mm512_packus_epi16(r4, r5);
+        __m512i s3 = _mm512_packus_epi16(r6, r7);
+
+
+        // store: 128-bit lanes 0..3 -> dest0..dest3
+        auto store4 = [&](__m512i s, int i)
+        {
+            _mm_storeu_si128(reinterpret_cast<__m128i *>(dest0) + i, _mm512_extracti32x4_epi32(s, 0));
+            _mm_storeu_si128(reinterpret_cast<__m128i *>(dest1) + i, _mm512_extracti32x4_epi32(s, 1));
+            _mm_storeu_si128(reinterpret_cast<__m128i *>(dest2) + i, _mm512_extracti32x4_epi32(s, 2));
+            _mm_storeu_si128(reinterpret_cast<__m128i *>(dest3) + i, _mm512_extracti32x4_epi32(s, 3));
+        };
+
+        store4(s0, 0);
+        store4(s1, 1);
+        store4(s2, 2);
+        store4(s3, 3);
+    }
+
+
+#endif // MANGO_ENABLE_AVX512
+
 #endif // MANGO_ENABLE_SSE2
 
 #if defined(MANGO_ENABLE_NEON)

--- a/source/mango/jpeg/jpeg_idct.cpp
+++ b/source/mango/jpeg/jpeg_idct.cpp
@@ -522,14 +522,14 @@ namespace mango::image::jpeg
             const __m128i* q0 = reinterpret_cast<const __m128i *>(qt[idx + 0]);
             const __m128i* q1 = reinterpret_cast<const __m128i *>(qt[idx + 1]);
 
-            __m256i v0 = _mm256_mullo_epi16(_mm256_set_m128i(data1[0], data0[0]), _mm256_set_m128i(q1[0], q0[0]));
-            __m256i v1 = _mm256_mullo_epi16(_mm256_set_m128i(data1[1], data0[1]), _mm256_set_m128i(q1[1], q0[1]));
-            __m256i v2 = _mm256_mullo_epi16(_mm256_set_m128i(data1[2], data0[2]), _mm256_set_m128i(q1[2], q0[2]));
-            __m256i v3 = _mm256_mullo_epi16(_mm256_set_m128i(data1[3], data0[3]), _mm256_set_m128i(q1[3], q0[3]));
-            __m256i v4 = _mm256_mullo_epi16(_mm256_set_m128i(data1[4], data0[4]), _mm256_set_m128i(q1[4], q0[4]));
-            __m256i v5 = _mm256_mullo_epi16(_mm256_set_m128i(data1[5], data0[5]), _mm256_set_m128i(q1[5], q0[5]));
-            __m256i v6 = _mm256_mullo_epi16(_mm256_set_m128i(data1[6], data0[6]), _mm256_set_m128i(q1[6], q0[6]));
-            __m256i v7 = _mm256_mullo_epi16(_mm256_set_m128i(data1[7], data0[7]), _mm256_set_m128i(q1[7], q0[7]));
+            __m256i v0 = _mm256_mullo_epi16(_mm256_loadu2_m128i(&data1[0], &data0[0]), _mm256_loadu2_m128i(&q1[0], &q0[0]));
+            __m256i v1 = _mm256_mullo_epi16(_mm256_loadu2_m128i(&data1[1], &data0[1]), _mm256_loadu2_m128i(&q1[1], &q0[1]));
+            __m256i v2 = _mm256_mullo_epi16(_mm256_loadu2_m128i(&data1[2], &data0[2]), _mm256_loadu2_m128i(&q1[2], &q0[2]));
+            __m256i v3 = _mm256_mullo_epi16(_mm256_loadu2_m128i(&data1[3], &data0[3]), _mm256_loadu2_m128i(&q1[3], &q0[3]));
+            __m256i v4 = _mm256_mullo_epi16(_mm256_loadu2_m128i(&data1[4], &data0[4]), _mm256_loadu2_m128i(&q1[4], &q0[4]));
+            __m256i v5 = _mm256_mullo_epi16(_mm256_loadu2_m128i(&data1[5], &data0[5]), _mm256_loadu2_m128i(&q1[5], &q0[5]));
+            __m256i v6 = _mm256_mullo_epi16(_mm256_loadu2_m128i(&data1[6], &data0[6]), _mm256_loadu2_m128i(&q1[6], &q0[6]));
+            __m256i v7 = _mm256_mullo_epi16(_mm256_loadu2_m128i(&data1[7], &data0[7]), _mm256_loadu2_m128i(&q1[7], &q0[7]));
 
             __m256i r_xmm0, r_xmm1, r_xmm2, r_xmm3, r_xmm4, r_xmm5, r_xmm6, r_xmm7;
             __m256i row0, row1, row2, row3, row4, row5, row6, row7;
@@ -775,14 +775,11 @@ namespace mango::image::jpeg
             __m256i s2 = _mm256_packus_epi16(r4, r5);
             __m256i s3 = _mm256_packus_epi16(r6, r7);
 
-            _mm256_storeu2_m128i(reinterpret_cast<__m128i *>(dest + 64) + 0,
-                                 reinterpret_cast<__m128i *>(dest) + 0, s0);
-            _mm256_storeu2_m128i(reinterpret_cast<__m128i *>(dest + 64) + 1,
-                                 reinterpret_cast<__m128i *>(dest) + 1, s1);
-            _mm256_storeu2_m128i(reinterpret_cast<__m128i *>(dest + 64) + 2,
-                                 reinterpret_cast<__m128i *>(dest) + 2, s2);
-            _mm256_storeu2_m128i(reinterpret_cast<__m128i *>(dest + 64) + 3,
-                                 reinterpret_cast<__m128i *>(dest) + 3, s3);
+            __m128i* d = reinterpret_cast<__m128i*>(dest);
+            _mm256_storeu2_m128i(d + 4, d + 0, s0);
+            _mm256_storeu2_m128i(d + 5, d + 1, s1);
+            _mm256_storeu2_m128i(d + 6, d + 2, s2);
+            _mm256_storeu2_m128i(d + 7, d + 3, s3);
 
             dest += 128;
             src += 128;

--- a/source/mango/jpeg/jpeg_idct.cpp
+++ b/source/mango/jpeg/jpeg_idct.cpp
@@ -1,6 +1,6 @@
 /*
     MANGO Multimedia Development Platform
-    Copyright (C) 2012-2023 Twilight Finland 3D Oy Ltd. All rights reserved.
+    Copyright (C) 2012-2026 Twilight Finland 3D Oy Ltd. All rights reserved.
 */
 #include "jpeg.hpp"
 
@@ -485,6 +485,298 @@ namespace mango::image::jpeg
         _mm_storeu_si128(d + 2, s2);
         _mm_storeu_si128(d + 3, s3);
     }
+
+#if defined(MANGO_ENABLE_AVX2)
+
+    // Dual 8x8 iDCT: block A in the low 128-bit lane, block B in the high lane.
+    // Both blocks share the same quantization table (same block index in adjacent MCUs).
+    void idct_avx2(u8* dest0, u8* dest1, const s16* src0, const s16* src1, const s16* qt)
+    {
+        const __m128i* data0 = reinterpret_cast<const __m128i *>(src0);
+        const __m128i* data1 = reinterpret_cast<const __m128i *>(src1);
+        const __m128i* qtable = reinterpret_cast<const __m128i *>(qt);
+
+        __m256i v0 = _mm256_mullo_epi16(_mm256_set_m128i(data1[0], data0[0]), _mm256_broadcastsi128_si256(qtable[0]));
+        __m256i v1 = _mm256_mullo_epi16(_mm256_set_m128i(data1[1], data0[1]), _mm256_broadcastsi128_si256(qtable[1]));
+        __m256i v2 = _mm256_mullo_epi16(_mm256_set_m128i(data1[2], data0[2]), _mm256_broadcastsi128_si256(qtable[2]));
+        __m256i v3 = _mm256_mullo_epi16(_mm256_set_m128i(data1[3], data0[3]), _mm256_broadcastsi128_si256(qtable[3]));
+        __m256i v4 = _mm256_mullo_epi16(_mm256_set_m128i(data1[4], data0[4]), _mm256_broadcastsi128_si256(qtable[4]));
+        __m256i v5 = _mm256_mullo_epi16(_mm256_set_m128i(data1[5], data0[5]), _mm256_broadcastsi128_si256(qtable[5]));
+        __m256i v6 = _mm256_mullo_epi16(_mm256_set_m128i(data1[6], data0[6]), _mm256_broadcastsi128_si256(qtable[6]));
+        __m256i v7 = _mm256_mullo_epi16(_mm256_set_m128i(data1[7], data0[7]), _mm256_broadcastsi128_si256(qtable[7]));
+
+        __m256i r_xmm0, r_xmm1, r_xmm2, r_xmm3, r_xmm4, r_xmm5, r_xmm6, r_xmm7;
+        __m256i row0, row1, row2, row3, row4, row5, row6, row7;
+
+        // row 1 and Row 3
+
+        const __m128i* table04 = reinterpret_cast<const __m128i*>(shortM128_tab_i_04);
+        const __m128i* table26 = reinterpret_cast<const __m128i*>(shortM128_tab_i_26);
+
+        r_xmm0 = _mm256_shufflelo_epi16(v0, 0xd8);
+        r_xmm1 = _mm256_shuffle_epi32(r_xmm0, 0x00);
+        r_xmm1 = _mm256_madd_epi16(r_xmm1, _mm256_broadcastsi128_si256(table04[0]));
+        r_xmm3 = _mm256_shuffle_epi32(r_xmm0, 0x55);
+        r_xmm0 = _mm256_shufflehi_epi16(r_xmm0, 0xd8);
+        r_xmm3 = _mm256_madd_epi16(r_xmm3, _mm256_broadcastsi128_si256(table04[2]));
+        r_xmm2 = _mm256_shuffle_epi32(r_xmm0, 0xaa);
+        r_xmm0 = _mm256_shuffle_epi32(r_xmm0, 0xff);
+        r_xmm2 = _mm256_madd_epi16(r_xmm2, _mm256_broadcastsi128_si256(table04[1]));
+
+        const __m256i round_inv_row = _mm256_set1_epi32(2048);
+
+        r_xmm4 = _mm256_shufflehi_epi16(v2, 0xd8);
+        r_xmm1 = _mm256_add_epi32(r_xmm1, round_inv_row);
+        r_xmm4 = _mm256_shufflelo_epi16(r_xmm4, 0xd8);
+        r_xmm0 = _mm256_madd_epi16(r_xmm0, _mm256_broadcastsi128_si256(table04[3]));
+        r_xmm5 = _mm256_shuffle_epi32(r_xmm4, 0x00);
+        r_xmm6 = _mm256_shuffle_epi32(r_xmm4, 0xaa);
+        r_xmm5 = _mm256_madd_epi16(r_xmm5, _mm256_broadcastsi128_si256(table26[0]));
+        r_xmm1 = _mm256_add_epi32(r_xmm1, r_xmm2);
+        r_xmm7 = _mm256_shuffle_epi32(r_xmm4, 0x55);
+        r_xmm6 = _mm256_madd_epi16(r_xmm6, _mm256_broadcastsi128_si256(table26[1]));
+        r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm3);
+        r_xmm4 = _mm256_shuffle_epi32(r_xmm4, 0xff);
+        r_xmm2 = _mm256_sub_epi32(r_xmm1, r_xmm0);
+        r_xmm7 = _mm256_madd_epi16(r_xmm7, _mm256_broadcastsi128_si256(table26[2]));
+        r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm1);
+        r_xmm2 = _mm256_srai_epi32(r_xmm2, 12);
+        r_xmm5 = _mm256_add_epi32(r_xmm5, round_inv_row);
+        r_xmm4 = _mm256_madd_epi16(r_xmm4, _mm256_broadcastsi128_si256(table26[3]));
+        r_xmm5 = _mm256_add_epi32(r_xmm5, r_xmm6);
+        r_xmm0 = _mm256_srai_epi32(r_xmm0, 12);
+        r_xmm2 = _mm256_shuffle_epi32(r_xmm2, 0x1b);
+        row0 = _mm256_packs_epi32(r_xmm0, r_xmm2);
+
+        r_xmm4 = _mm256_add_epi32(r_xmm4, r_xmm7);
+        r_xmm6 = _mm256_sub_epi32(r_xmm5, r_xmm4);
+        r_xmm4 = _mm256_add_epi32(r_xmm4, r_xmm5);
+        r_xmm6 = _mm256_srai_epi32(r_xmm6, 12);
+        r_xmm4 = _mm256_srai_epi32(r_xmm4, 12);
+        r_xmm6 = _mm256_shuffle_epi32(r_xmm6, 0x1b);
+        row2 = _mm256_packs_epi32(r_xmm4, r_xmm6);
+
+        // row 5 and row 7
+
+        r_xmm0 = _mm256_shufflelo_epi16(v4, 0xd8);
+        r_xmm1 = _mm256_shuffle_epi32(r_xmm0, 0x00);
+        r_xmm1 = _mm256_madd_epi16(r_xmm1, _mm256_broadcastsi128_si256(table04[0]));
+        r_xmm3 = _mm256_shuffle_epi32(r_xmm0, 0x55);
+        r_xmm0 = _mm256_shufflehi_epi16(r_xmm0, 0xd8);
+        r_xmm3 = _mm256_madd_epi16(r_xmm3, _mm256_broadcastsi128_si256(table04[2]));
+        r_xmm2 = _mm256_shuffle_epi32(r_xmm0, 0xaa);
+        r_xmm0 = _mm256_shuffle_epi32(r_xmm0, 0xff);
+        r_xmm2 = _mm256_madd_epi16(r_xmm2, _mm256_broadcastsi128_si256(table04[1]));
+        r_xmm4 = _mm256_shufflehi_epi16(v6, 0xd8);
+        r_xmm1 = _mm256_add_epi32(r_xmm1, round_inv_row);
+        r_xmm4 = _mm256_shufflelo_epi16(r_xmm4, 0xd8);
+        r_xmm0 = _mm256_madd_epi16(r_xmm0, _mm256_broadcastsi128_si256(table04[3]));
+        r_xmm5 = _mm256_shuffle_epi32(r_xmm4, 0x00);
+        r_xmm6 = _mm256_shuffle_epi32(r_xmm4, 0xaa);
+        r_xmm5 = _mm256_madd_epi16(r_xmm5, _mm256_broadcastsi128_si256(table26[0]));
+        r_xmm1 = _mm256_add_epi32(r_xmm1, r_xmm2);
+        r_xmm7 = _mm256_shuffle_epi32(r_xmm4, 0x55);
+        r_xmm6 = _mm256_madd_epi16(r_xmm6, _mm256_broadcastsi128_si256(table26[1]));
+        r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm3);
+        r_xmm4 = _mm256_shuffle_epi32(r_xmm4, 0xff);
+        r_xmm2 = _mm256_sub_epi32(r_xmm1, r_xmm0);
+        r_xmm7 = _mm256_madd_epi16(r_xmm7, _mm256_broadcastsi128_si256(table26[2]));
+        r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm1);
+        r_xmm2 = _mm256_srai_epi32(r_xmm2, 12);
+        r_xmm5 = _mm256_add_epi32(r_xmm5, round_inv_row);
+        r_xmm4 = _mm256_madd_epi16(r_xmm4, _mm256_broadcastsi128_si256(table26[3]));
+        r_xmm5 = _mm256_add_epi32(r_xmm5, r_xmm6);
+        r_xmm0 = _mm256_srai_epi32(r_xmm0, 12);
+        r_xmm2 = _mm256_shuffle_epi32(r_xmm2, 0x1b);
+        row4 = _mm256_packs_epi32(r_xmm0, r_xmm2);
+
+        r_xmm4 = _mm256_add_epi32(r_xmm4, r_xmm7);
+        r_xmm6 = _mm256_sub_epi32(r_xmm5, r_xmm4);
+        r_xmm4 = _mm256_add_epi32(r_xmm4, r_xmm5);
+        r_xmm6 = _mm256_srai_epi32(r_xmm6, 12);
+        r_xmm4 = _mm256_srai_epi32(r_xmm4, 12);
+        r_xmm6 = _mm256_shuffle_epi32(r_xmm6, 0x1b);
+        row6 = _mm256_packs_epi32(r_xmm4, r_xmm6);
+
+        // row 4 and row 2
+
+        const __m128i* table35 = reinterpret_cast<const __m128i*>(shortM128_tab_i_35);
+        const __m128i* table17 = reinterpret_cast<const __m128i*>(shortM128_tab_i_17);
+
+        r_xmm0 = _mm256_shufflelo_epi16(v3, 0xd8);
+        r_xmm1 = _mm256_shuffle_epi32(r_xmm0, 0x00);
+        r_xmm1 = _mm256_madd_epi16(r_xmm1, _mm256_broadcastsi128_si256(table35[0]));
+        r_xmm3 = _mm256_shuffle_epi32(r_xmm0, 0x55);
+        r_xmm0 = _mm256_shufflehi_epi16(r_xmm0, 0xd8);
+        r_xmm3 = _mm256_madd_epi16(r_xmm3, _mm256_broadcastsi128_si256(table35[2]));
+        r_xmm2 = _mm256_shuffle_epi32(r_xmm0, 0xaa);
+        r_xmm0 = _mm256_shuffle_epi32(r_xmm0, 0xff);
+        r_xmm2 = _mm256_madd_epi16(r_xmm2, _mm256_broadcastsi128_si256(table35[1]));
+        r_xmm4 = _mm256_shufflehi_epi16(v1, 0xd8);
+        r_xmm1 = _mm256_add_epi32(r_xmm1, round_inv_row);
+        r_xmm4 = _mm256_shufflelo_epi16(r_xmm4, 0xd8);
+        r_xmm0 = _mm256_madd_epi16(r_xmm0, _mm256_broadcastsi128_si256(table35[3]));
+        r_xmm5 = _mm256_shuffle_epi32(r_xmm4, 0x00);
+        r_xmm6 = _mm256_shuffle_epi32(r_xmm4, 0xaa);
+        r_xmm5 = _mm256_madd_epi16(r_xmm5, _mm256_broadcastsi128_si256(table17[0]));
+        r_xmm1 = _mm256_add_epi32(r_xmm1, r_xmm2);
+        r_xmm7 = _mm256_shuffle_epi32(r_xmm4, 0x55);
+        r_xmm6 = _mm256_madd_epi16(r_xmm6, _mm256_broadcastsi128_si256(table17[1]));
+        r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm3);
+        r_xmm4 = _mm256_shuffle_epi32(r_xmm4, 0xff);
+        r_xmm2 = _mm256_sub_epi32(r_xmm1, r_xmm0);
+        r_xmm7 = _mm256_madd_epi16(r_xmm7, _mm256_broadcastsi128_si256(table17[2]));
+        r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm1);
+        r_xmm2 = _mm256_srai_epi32(r_xmm2, 12);
+        r_xmm5 = _mm256_add_epi32(r_xmm5, round_inv_row);
+        r_xmm4 = _mm256_madd_epi16(r_xmm4, _mm256_broadcastsi128_si256(table17[3]));
+        r_xmm5 = _mm256_add_epi32(r_xmm5, r_xmm6);
+        r_xmm0 = _mm256_srai_epi32(r_xmm0, 12);
+        r_xmm2 = _mm256_shuffle_epi32(r_xmm2, 0x1b);
+        row3 = _mm256_packs_epi32(r_xmm0, r_xmm2);
+
+        r_xmm4 = _mm256_add_epi32(r_xmm4, r_xmm7);
+        r_xmm6 = _mm256_sub_epi32(r_xmm5, r_xmm4);
+        r_xmm4 = _mm256_add_epi32(r_xmm5, r_xmm4);
+        r_xmm6 = _mm256_srai_epi32(r_xmm6, 12);
+        r_xmm4 = _mm256_srai_epi32(r_xmm4, 12);
+        r_xmm6 = _mm256_shuffle_epi32(r_xmm6, 0x1b);
+        row1 = _mm256_packs_epi32(r_xmm4, r_xmm6);
+
+        // row 6 and row 8
+
+        r_xmm0 = _mm256_shufflelo_epi16(v5, 0xd8);
+        r_xmm1 = _mm256_shuffle_epi32(r_xmm0, 0x00);
+        r_xmm1 = _mm256_madd_epi16(r_xmm1, _mm256_broadcastsi128_si256(table35[0]));
+        r_xmm3 = _mm256_shuffle_epi32(r_xmm0, 0x55);
+        r_xmm0 = _mm256_shufflehi_epi16(r_xmm0, 0xd8);
+        r_xmm3 = _mm256_madd_epi16(r_xmm3, _mm256_broadcastsi128_si256(table35[2]));
+        r_xmm2 = _mm256_shuffle_epi32(r_xmm0, 0xaa);
+        r_xmm0 = _mm256_shuffle_epi32(r_xmm0, 0xff);
+        r_xmm2 = _mm256_madd_epi16(r_xmm2, _mm256_broadcastsi128_si256(table35[1]));
+        r_xmm4 = _mm256_shufflehi_epi16(v7, 0xd8);
+        r_xmm1 = _mm256_add_epi32(r_xmm1, round_inv_row);
+        r_xmm4 = _mm256_shufflelo_epi16(r_xmm4, 0xd8);
+        r_xmm0 = _mm256_madd_epi16(r_xmm0, _mm256_broadcastsi128_si256(table35[3]));
+        r_xmm5 = _mm256_shuffle_epi32(r_xmm4, 0x00);
+        r_xmm6 = _mm256_shuffle_epi32(r_xmm4, 0xaa);
+        r_xmm5 = _mm256_madd_epi16(r_xmm5, _mm256_broadcastsi128_si256(table17[0]));
+        r_xmm1 = _mm256_add_epi32(r_xmm1, r_xmm2);
+        r_xmm7 = _mm256_shuffle_epi32(r_xmm4, 0x55);
+        r_xmm6 = _mm256_madd_epi16(r_xmm6, _mm256_broadcastsi128_si256(table17[1]));
+        r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm3);
+        r_xmm4 = _mm256_shuffle_epi32(r_xmm4, 0xff);
+        r_xmm2 = _mm256_sub_epi32(r_xmm1, r_xmm0);
+        r_xmm7 = _mm256_madd_epi16(r_xmm7, _mm256_broadcastsi128_si256(table17[2]));
+        r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm1);
+        r_xmm2 = _mm256_srai_epi32(r_xmm2, 12);
+        r_xmm5 = _mm256_add_epi32(r_xmm5, round_inv_row);
+        r_xmm4 = _mm256_madd_epi16(r_xmm4, _mm256_broadcastsi128_si256(table17[3]));
+        r_xmm5 = _mm256_add_epi32(r_xmm5, r_xmm6);
+        r_xmm0 = _mm256_srai_epi32(r_xmm0, 12);
+        r_xmm2 = _mm256_shuffle_epi32(r_xmm2, 0x1b);
+        row5 = _mm256_packs_epi32(r_xmm0, r_xmm2);
+
+        r_xmm4 = _mm256_add_epi32(r_xmm4, r_xmm7);
+        r_xmm6 = _mm256_sub_epi32(r_xmm5, r_xmm4);
+        r_xmm4 = _mm256_add_epi32(r_xmm5, r_xmm4);
+        r_xmm6 = _mm256_srai_epi32(r_xmm6, 12);
+        r_xmm4 = _mm256_srai_epi32(r_xmm4, 12);
+        r_xmm6 = _mm256_shuffle_epi32(r_xmm6, 0x1b);
+        row7 = _mm256_packs_epi32(r_xmm4, r_xmm6);
+
+        const __m256i tg = _mm256_broadcastsi128_si256(_mm_set_epi16(-19195, -19195, -21746, -21746, 27146, 27146, 13036, 13036));
+        const __m256i one = _mm256_set1_epi16(1);
+
+        r_xmm1 = _mm256_shuffle_epi32(tg, 0xaa);
+        r_xmm0 = _mm256_mulhi_epi16(r_xmm1, row5);
+        r_xmm1 = _mm256_mulhi_epi16(r_xmm1, row3);
+        r_xmm5 = _mm256_shuffle_epi32(tg, 0x00);
+        r_xmm4 = _mm256_mulhi_epi16(r_xmm5, row7);
+        r_xmm5 = _mm256_mulhi_epi16(r_xmm5, row1);
+        r_xmm0 = _mm256_adds_epi16(r_xmm0, row5);
+        r_xmm1 = _mm256_adds_epi16(r_xmm1, row3);
+        r_xmm0 = _mm256_adds_epi16(r_xmm0, row3);
+        r_xmm3 = _mm256_shuffle_epi32(tg, 0x55);
+        r_xmm7 = _mm256_mulhi_epi16(r_xmm3, row6);
+        r_xmm3 = _mm256_mulhi_epi16(r_xmm3, row2);
+        r_xmm5 = _mm256_subs_epi16(r_xmm5, row7);
+        r_xmm4 = _mm256_adds_epi16(r_xmm4, row1);
+        r_xmm2 = _mm256_subs_epi16(r_xmm2, r_xmm1);
+        r_xmm1 = _mm256_adds_epi16(r_xmm0, r_xmm4);
+        r_xmm1 = _mm256_adds_epi16(r_xmm1, one);
+        r_xmm4 = _mm256_subs_epi16(r_xmm4, r_xmm0);
+        r_xmm6 = _mm256_adds_epi16(r_xmm5, r_xmm2);
+        r_xmm5 = _mm256_subs_epi16(r_xmm5, r_xmm2);
+        r_xmm5 = _mm256_adds_epi16(r_xmm5, one);
+
+        __m256i temp7 = r_xmm1;
+        __m256i temp3 = r_xmm6;
+
+        r_xmm0 = _mm256_shuffle_epi32(tg, 0xff);
+        r_xmm1 = _mm256_subs_epi16(r_xmm4, r_xmm5);
+        r_xmm4 = _mm256_adds_epi16(r_xmm4, r_xmm5);
+        r_xmm2 = _mm256_mulhi_epi16(r_xmm0, r_xmm4);
+        r_xmm7 = _mm256_adds_epi16(r_xmm7, row2);
+        r_xmm3 = _mm256_subs_epi16(r_xmm3, row6);
+        r_xmm0 = _mm256_mulhi_epi16(r_xmm0, r_xmm1);
+        r_xmm0 = _mm256_adds_epi16(r_xmm0, r_xmm1);
+        r_xmm5 = _mm256_adds_epi16(row0, row4);
+        r_xmm6 = _mm256_subs_epi16(row0, row4);
+        r_xmm4 = _mm256_adds_epi16(r_xmm4, r_xmm2);
+
+        r_xmm4 = _mm256_or_si256(r_xmm4, one);
+        r_xmm0 = _mm256_or_si256(r_xmm0, one);
+
+        const s16 bias = 128 << 5;
+        const __m256i round_inv_col = _mm256_set1_epi16(16 + bias);
+        const __m256i round_inv_corr = _mm256_sub_epi16(round_inv_col, one);
+
+        r_xmm1 = _mm256_subs_epi16(r_xmm6, r_xmm3);
+        r_xmm1 = _mm256_adds_epi16(r_xmm1, round_inv_corr);
+        r_xmm2 = _mm256_subs_epi16(r_xmm5, r_xmm7);
+        r_xmm2 = _mm256_adds_epi16(r_xmm2, round_inv_corr);
+        r_xmm5 = _mm256_adds_epi16(r_xmm5, r_xmm7);
+        r_xmm5 = _mm256_adds_epi16(r_xmm5, round_inv_col);
+        r_xmm6 = _mm256_adds_epi16(r_xmm6, r_xmm3);
+        r_xmm6 = _mm256_adds_epi16(r_xmm6, round_inv_col);
+
+        __m256i r0 = _mm256_adds_epi16(r_xmm5, temp7);
+        __m256i r1 = _mm256_adds_epi16(r_xmm6, r_xmm4);
+        __m256i r2 = _mm256_adds_epi16(r_xmm1, r_xmm0);
+        __m256i r3 = _mm256_adds_epi16(r_xmm2, temp3);
+        __m256i r4 = _mm256_subs_epi16(r_xmm2, temp3);
+        __m256i r5 = _mm256_subs_epi16(r_xmm1, r_xmm0);
+        __m256i r6 = _mm256_subs_epi16(r_xmm6, r_xmm4);
+        __m256i r7 = _mm256_subs_epi16(r_xmm5, temp7);
+
+        r0 = _mm256_srai_epi16(r0, 5);
+        r1 = _mm256_srai_epi16(r1, 5);
+        r2 = _mm256_srai_epi16(r2, 5);
+        r3 = _mm256_srai_epi16(r3, 5);
+        r4 = _mm256_srai_epi16(r4, 5);
+        r5 = _mm256_srai_epi16(r5, 5);
+        r6 = _mm256_srai_epi16(r6, 5);
+        r7 = _mm256_srai_epi16(r7, 5);
+
+        __m256i s0 = _mm256_packus_epi16(r0, r1);
+        __m256i s1 = _mm256_packus_epi16(r2, r3);
+        __m256i s2 = _mm256_packus_epi16(r4, r5);
+        __m256i s3 = _mm256_packus_epi16(r6, r7);
+
+
+        // store: low lane -> dest0, high lane -> dest1
+        _mm256_storeu2_m128i(reinterpret_cast<__m128i *>(dest1) + 0,
+                             reinterpret_cast<__m128i *>(dest0) + 0, s0);
+        _mm256_storeu2_m128i(reinterpret_cast<__m128i *>(dest1) + 1,
+                             reinterpret_cast<__m128i *>(dest0) + 1, s1);
+        _mm256_storeu2_m128i(reinterpret_cast<__m128i *>(dest1) + 2,
+                             reinterpret_cast<__m128i *>(dest0) + 2, s2);
+        _mm256_storeu2_m128i(reinterpret_cast<__m128i *>(dest1) + 3,
+                             reinterpret_cast<__m128i *>(dest0) + 3, s3);
+    }
+
+#endif // MANGO_ENABLE_AVX2
 
 #endif // MANGO_ENABLE_SSE2
 

--- a/source/mango/jpeg/jpeg_idct.cpp
+++ b/source/mango/jpeg/jpeg_idct.cpp
@@ -204,884 +204,954 @@ namespace mango::image::jpeg
         15137, 5315, -26722, -15137, 5315, 22654, 22654, -26722
     };
 
-    void idct_sse2(u8* dest, const s16* src, const s16* qt)
+    void idct_sse2_n(u8* dest, const s16* src, const s16* const* qt, int blocks, int idx, int count)
     {
-        const __m128i* data = reinterpret_cast<const __m128i *>(src);
-        const __m128i* qtable = reinterpret_cast<const __m128i *>(qt);
-
-        // Load and dequantize
-        __m128i v0 = _mm_mullo_epi16(data[0], qtable[0]);
-        __m128i v1 = _mm_mullo_epi16(data[1], qtable[1]);
-        __m128i v2 = _mm_mullo_epi16(data[2], qtable[2]);
-        __m128i v3 = _mm_mullo_epi16(data[3], qtable[3]);
-        __m128i v4 = _mm_mullo_epi16(data[4], qtable[4]);
-        __m128i v5 = _mm_mullo_epi16(data[5], qtable[5]);
-        __m128i v6 = _mm_mullo_epi16(data[6], qtable[6]);
-        __m128i v7 = _mm_mullo_epi16(data[7], qtable[7]);
-
-        __m128i r_xmm0, r_xmm1, r_xmm2, r_xmm3, r_xmm4, r_xmm5, r_xmm6, r_xmm7;
-        __m128i row0, row1, row2, row3, row4, row5, row6, row7;
-
-        // row 1 and Row 3
-
         const __m128i* table04 = reinterpret_cast<const __m128i*>(shortM128_tab_i_04);
         const __m128i* table26 = reinterpret_cast<const __m128i*>(shortM128_tab_i_26);
-
-        r_xmm0 = _mm_shufflelo_epi16(v0, 0xd8);
-        r_xmm1 = _mm_shuffle_epi32(r_xmm0, 0x00);
-        r_xmm1 = _mm_madd_epi16(r_xmm1, table04[0]);
-        r_xmm3 = _mm_shuffle_epi32(r_xmm0, 0x55);
-        r_xmm0 = _mm_shufflehi_epi16(r_xmm0, 0xd8);
-        r_xmm3 = _mm_madd_epi16(r_xmm3, table04[2]);
-        r_xmm2 = _mm_shuffle_epi32(r_xmm0, 0xaa);
-        r_xmm0 = _mm_shuffle_epi32(r_xmm0, 0xff);
-        r_xmm2 = _mm_madd_epi16(r_xmm2, table04[1]);
-
-        const __m128i round_inv_row = _mm_set1_epi32(2048);
-
-        r_xmm4 = _mm_shufflehi_epi16(v2, 0xd8);
-        r_xmm1 = _mm_add_epi32(r_xmm1, round_inv_row);
-        r_xmm4 = _mm_shufflelo_epi16(r_xmm4, 0xd8);
-        r_xmm0 = _mm_madd_epi16(r_xmm0, table04[3]);
-        r_xmm5 = _mm_shuffle_epi32(r_xmm4, 0x00);
-        r_xmm6 = _mm_shuffle_epi32(r_xmm4, 0xaa);
-        r_xmm5 = _mm_madd_epi16(r_xmm5, table26[0]);
-        r_xmm1 = _mm_add_epi32(r_xmm1, r_xmm2);
-        r_xmm7 = _mm_shuffle_epi32(r_xmm4, 0x55);
-        r_xmm6 = _mm_madd_epi16(r_xmm6, table26[1]);
-        r_xmm0 = _mm_add_epi32(r_xmm0, r_xmm3);
-        r_xmm4 = _mm_shuffle_epi32(r_xmm4, 0xff);
-        r_xmm2 = _mm_sub_epi32(r_xmm1, r_xmm0);
-        r_xmm7 = _mm_madd_epi16(r_xmm7, table26[2]);
-        r_xmm0 = _mm_add_epi32(r_xmm0, r_xmm1);
-        r_xmm2 = _mm_srai_epi32(r_xmm2, 12);
-        r_xmm5 = _mm_add_epi32(r_xmm5, round_inv_row);
-        r_xmm4 = _mm_madd_epi16(r_xmm4, table26[3]);
-        r_xmm5 = _mm_add_epi32(r_xmm5, r_xmm6);
-        r_xmm0 = _mm_srai_epi32(r_xmm0, 12);
-        r_xmm2 = _mm_shuffle_epi32(r_xmm2, 0x1b);
-        row0 = _mm_packs_epi32(r_xmm0, r_xmm2);
-
-        r_xmm4 = _mm_add_epi32(r_xmm4, r_xmm7);
-        r_xmm6 = _mm_sub_epi32(r_xmm5, r_xmm4);
-        r_xmm4 = _mm_add_epi32(r_xmm4, r_xmm5);
-        r_xmm6 = _mm_srai_epi32(r_xmm6, 12);
-        r_xmm4 = _mm_srai_epi32(r_xmm4, 12);
-        r_xmm6 = _mm_shuffle_epi32(r_xmm6, 0x1b);
-        row2 = _mm_packs_epi32(r_xmm4, r_xmm6);
-
-        // row 5 and row 7
-
-        r_xmm0 = _mm_shufflelo_epi16(v4, 0xd8);
-        r_xmm1 = _mm_shuffle_epi32(r_xmm0, 0x00);
-        r_xmm1 = _mm_madd_epi16(r_xmm1, table04[0]);
-        r_xmm3 = _mm_shuffle_epi32(r_xmm0, 0x55);
-        r_xmm0 = _mm_shufflehi_epi16(r_xmm0, 0xd8);
-        r_xmm3 = _mm_madd_epi16(r_xmm3, table04[2]);
-        r_xmm2 = _mm_shuffle_epi32(r_xmm0, 0xaa);
-        r_xmm0 = _mm_shuffle_epi32(r_xmm0, 0xff);
-        r_xmm2 = _mm_madd_epi16(r_xmm2, table04[1]);
-        r_xmm4 = _mm_shufflehi_epi16(v6, 0xd8);
-        r_xmm1 = _mm_add_epi32(r_xmm1, round_inv_row);
-        r_xmm4 = _mm_shufflelo_epi16(r_xmm4, 0xd8);
-        r_xmm0 = _mm_madd_epi16(r_xmm0, table04[3]);
-        r_xmm5 = _mm_shuffle_epi32(r_xmm4, 0x00);
-        r_xmm6 = _mm_shuffle_epi32(r_xmm4, 0xaa);
-        r_xmm5 = _mm_madd_epi16(r_xmm5, table26[0]);
-        r_xmm1 = _mm_add_epi32(r_xmm1, r_xmm2);
-        r_xmm7 = _mm_shuffle_epi32(r_xmm4, 0x55);
-        r_xmm6 = _mm_madd_epi16(r_xmm6, table26[1]);
-        r_xmm0 = _mm_add_epi32(r_xmm0, r_xmm3);
-        r_xmm4 = _mm_shuffle_epi32(r_xmm4, 0xff);
-        r_xmm2 = _mm_sub_epi32(r_xmm1, r_xmm0);
-        r_xmm7 = _mm_madd_epi16(r_xmm7, table26[2]);
-        r_xmm0 = _mm_add_epi32(r_xmm0, r_xmm1);
-        r_xmm2 = _mm_srai_epi32(r_xmm2, 12);
-        r_xmm5 = _mm_add_epi32(r_xmm5, round_inv_row);
-        r_xmm4 = _mm_madd_epi16(r_xmm4, table26[3]);
-        r_xmm5 = _mm_add_epi32(r_xmm5, r_xmm6);
-        r_xmm0 = _mm_srai_epi32(r_xmm0, 12);
-        r_xmm2 = _mm_shuffle_epi32(r_xmm2, 0x1b);
-        row4 = _mm_packs_epi32(r_xmm0, r_xmm2);
-
-        r_xmm4 = _mm_add_epi32(r_xmm4, r_xmm7);
-        r_xmm6 = _mm_sub_epi32(r_xmm5, r_xmm4);
-        r_xmm4 = _mm_add_epi32(r_xmm4, r_xmm5);
-        r_xmm6 = _mm_srai_epi32(r_xmm6, 12);
-        r_xmm4 = _mm_srai_epi32(r_xmm4, 12);
-        r_xmm6 = _mm_shuffle_epi32(r_xmm6, 0x1b);
-        row6 = _mm_packs_epi32(r_xmm4, r_xmm6);
-
-        // row 4 and row 2
-
         const __m128i* table35 = reinterpret_cast<const __m128i*>(shortM128_tab_i_35);
         const __m128i* table17 = reinterpret_cast<const __m128i*>(shortM128_tab_i_17);
-
-        r_xmm0 = _mm_shufflelo_epi16(v3, 0xd8);
-        r_xmm1 = _mm_shuffle_epi32(r_xmm0, 0x00);
-        r_xmm1 = _mm_madd_epi16(r_xmm1, table35[0]);
-        r_xmm3 = _mm_shuffle_epi32(r_xmm0, 0x55);
-        r_xmm0 = _mm_shufflehi_epi16(r_xmm0, 0xd8);
-        r_xmm3 = _mm_madd_epi16(r_xmm3, table35[2]);
-        r_xmm2 = _mm_shuffle_epi32(r_xmm0, 0xaa);
-        r_xmm0 = _mm_shuffle_epi32(r_xmm0, 0xff);
-        r_xmm2 = _mm_madd_epi16(r_xmm2, table35[1]);
-        r_xmm4 = _mm_shufflehi_epi16(v1, 0xd8);
-        r_xmm1 = _mm_add_epi32(r_xmm1, round_inv_row);
-        r_xmm4 = _mm_shufflelo_epi16(r_xmm4, 0xd8);
-        r_xmm0 = _mm_madd_epi16(r_xmm0, table35[3]);
-        r_xmm5 = _mm_shuffle_epi32(r_xmm4, 0x00);
-        r_xmm6 = _mm_shuffle_epi32(r_xmm4, 0xaa);
-        r_xmm5 = _mm_madd_epi16(r_xmm5, table17[0]);
-        r_xmm1 = _mm_add_epi32(r_xmm1, r_xmm2);
-        r_xmm7 = _mm_shuffle_epi32(r_xmm4, 0x55);
-        r_xmm6 = _mm_madd_epi16(r_xmm6, table17[1]);
-        r_xmm0 = _mm_add_epi32(r_xmm0, r_xmm3);
-        r_xmm4 = _mm_shuffle_epi32(r_xmm4, 0xff);
-        r_xmm2 = _mm_sub_epi32(r_xmm1, r_xmm0);
-        r_xmm7 = _mm_madd_epi16(r_xmm7, table17[2]);
-        r_xmm0 = _mm_add_epi32(r_xmm0, r_xmm1);
-        r_xmm2 = _mm_srai_epi32(r_xmm2, 12);
-        r_xmm5 = _mm_add_epi32(r_xmm5, round_inv_row);
-        r_xmm4 = _mm_madd_epi16(r_xmm4, table17[3]);
-        r_xmm5 = _mm_add_epi32(r_xmm5, r_xmm6);
-        r_xmm0 = _mm_srai_epi32(r_xmm0, 12);
-        r_xmm2 = _mm_shuffle_epi32(r_xmm2, 0x1b);
-        row3 = _mm_packs_epi32(r_xmm0, r_xmm2);
-
-        r_xmm4 = _mm_add_epi32(r_xmm4, r_xmm7);
-        r_xmm6 = _mm_sub_epi32(r_xmm5, r_xmm4);
-        r_xmm4 = _mm_add_epi32(r_xmm5, r_xmm4);
-        r_xmm6 = _mm_srai_epi32(r_xmm6, 12);
-        r_xmm4 = _mm_srai_epi32(r_xmm4, 12);
-        r_xmm6 = _mm_shuffle_epi32(r_xmm6, 0x1b);
-        row1 = _mm_packs_epi32(r_xmm4, r_xmm6);
-
-        // row 6 and row 8
-
-        r_xmm0 = _mm_shufflelo_epi16(v5, 0xd8);
-        r_xmm1 = _mm_shuffle_epi32(r_xmm0, 0x00);
-        r_xmm1 = _mm_madd_epi16(r_xmm1, table35[0]);
-        r_xmm3 = _mm_shuffle_epi32(r_xmm0, 0x55);
-        r_xmm0 = _mm_shufflehi_epi16(r_xmm0, 0xd8);
-        r_xmm3 = _mm_madd_epi16(r_xmm3, table35[2]);
-        r_xmm2 = _mm_shuffle_epi32(r_xmm0, 0xaa);
-        r_xmm0 = _mm_shuffle_epi32(r_xmm0, 0xff);
-        r_xmm2 = _mm_madd_epi16(r_xmm2, table35[1]);
-        r_xmm4 = _mm_shufflehi_epi16(v7, 0xd8);
-        r_xmm1 = _mm_add_epi32(r_xmm1, round_inv_row);
-        r_xmm4 = _mm_shufflelo_epi16(r_xmm4, 0xd8);
-        r_xmm0 = _mm_madd_epi16(r_xmm0, table35[3]);
-        r_xmm5 = _mm_shuffle_epi32(r_xmm4, 0x00);
-        r_xmm6 = _mm_shuffle_epi32(r_xmm4, 0xaa);
-        r_xmm5 = _mm_madd_epi16(r_xmm5, table17[0]);
-        r_xmm1 = _mm_add_epi32(r_xmm1, r_xmm2);
-        r_xmm7 = _mm_shuffle_epi32(r_xmm4, 0x55);
-        r_xmm6 = _mm_madd_epi16(r_xmm6, table17[1]);
-        r_xmm0 = _mm_add_epi32(r_xmm0, r_xmm3);
-        r_xmm4 = _mm_shuffle_epi32(r_xmm4, 0xff);
-        r_xmm2 = _mm_sub_epi32(r_xmm1, r_xmm0);
-        r_xmm7 = _mm_madd_epi16(r_xmm7, table17[2]);
-        r_xmm0 = _mm_add_epi32(r_xmm0, r_xmm1);
-        r_xmm2 = _mm_srai_epi32(r_xmm2, 12);
-        r_xmm5 = _mm_add_epi32(r_xmm5, round_inv_row);
-        r_xmm4 = _mm_madd_epi16(r_xmm4, table17[3]);
-        r_xmm5 = _mm_add_epi32(r_xmm5, r_xmm6);
-        r_xmm0 = _mm_srai_epi32(r_xmm0, 12);
-        r_xmm2 = _mm_shuffle_epi32(r_xmm2, 0x1b);
-        row5 = _mm_packs_epi32(r_xmm0, r_xmm2);
-
-        r_xmm4 = _mm_add_epi32(r_xmm4, r_xmm7);
-        r_xmm6 = _mm_sub_epi32(r_xmm5, r_xmm4);
-        r_xmm4 = _mm_add_epi32(r_xmm5, r_xmm4);
-        r_xmm6 = _mm_srai_epi32(r_xmm6, 12);
-        r_xmm4 = _mm_srai_epi32(r_xmm4, 12);
-        r_xmm6 = _mm_shuffle_epi32(r_xmm6, 0x1b);
-        row7 = _mm_packs_epi32(r_xmm4, r_xmm6);
-
+        const __m128i round_inv_row = _mm_set1_epi32(2048);
         const __m128i tg = _mm_set_epi16(-19195, -19195, -21746, -21746, 27146, 27146, 13036, 13036);
         const __m128i one = _mm_set1_epi16(1);
-
-        r_xmm1 = _mm_shuffle_epi32(tg, 0xaa);
-        r_xmm0 = _mm_mulhi_epi16(r_xmm1, row5);
-        r_xmm1 = _mm_mulhi_epi16(r_xmm1, row3);
-        r_xmm5 = _mm_shuffle_epi32(tg, 0x00);
-        r_xmm4 = _mm_mulhi_epi16(r_xmm5, row7);
-        r_xmm5 = _mm_mulhi_epi16(r_xmm5, row1);
-        r_xmm0 = _mm_adds_epi16(r_xmm0, row5);
-        r_xmm1 = _mm_adds_epi16(r_xmm1, row3);
-        r_xmm0 = _mm_adds_epi16(r_xmm0, row3);
-        r_xmm3 = _mm_shuffle_epi32(tg, 0x55);
-        r_xmm7 = _mm_mulhi_epi16(r_xmm3, row6);
-        r_xmm3 = _mm_mulhi_epi16(r_xmm3, row2);
-        r_xmm5 = _mm_subs_epi16(r_xmm5, row7);
-        r_xmm4 = _mm_adds_epi16(r_xmm4, row1);
-        r_xmm2 = _mm_subs_epi16(r_xmm2, r_xmm1);
-        r_xmm1 = _mm_adds_epi16(r_xmm0, r_xmm4);
-        r_xmm1 = _mm_adds_epi16(r_xmm1, one);
-        r_xmm4 = _mm_subs_epi16(r_xmm4, r_xmm0);
-        r_xmm6 = _mm_adds_epi16(r_xmm5, r_xmm2);
-        r_xmm5 = _mm_subs_epi16(r_xmm5, r_xmm2);
-        r_xmm5 = _mm_adds_epi16(r_xmm5, one);
-
-        __m128i temp7 = r_xmm1;
-        __m128i temp3 = r_xmm6;
-
-        r_xmm0 = _mm_shuffle_epi32(tg, 0xff);
-        r_xmm1 = _mm_subs_epi16(r_xmm4, r_xmm5);
-        r_xmm4 = _mm_adds_epi16(r_xmm4, r_xmm5);
-        r_xmm2 = _mm_mulhi_epi16(r_xmm0, r_xmm4);
-        r_xmm7 = _mm_adds_epi16(r_xmm7, row2);
-        r_xmm3 = _mm_subs_epi16(r_xmm3, row6);
-        r_xmm0 = _mm_mulhi_epi16(r_xmm0, r_xmm1);
-        r_xmm0 = _mm_adds_epi16(r_xmm0, r_xmm1);
-        r_xmm5 = _mm_adds_epi16(row0, row4);
-        r_xmm6 = _mm_subs_epi16(row0, row4);
-        r_xmm4 = _mm_adds_epi16(r_xmm4, r_xmm2);
-
-        r_xmm4 = _mm_or_si128(r_xmm4, one);
-        r_xmm0 = _mm_or_si128(r_xmm0, one);
-
         const s16 bias = 128 << 5;
         const __m128i round_inv_col = _mm_set1_epi16(16 + bias);
         const __m128i round_inv_corr = _mm_sub_epi16(round_inv_col, one);
 
-        r_xmm1 = _mm_subs_epi16(r_xmm6, r_xmm3);
-        r_xmm1 = _mm_adds_epi16(r_xmm1, round_inv_corr);
-        r_xmm2 = _mm_subs_epi16(r_xmm5, r_xmm7);
-        r_xmm2 = _mm_adds_epi16(r_xmm2, round_inv_corr);
-        r_xmm5 = _mm_adds_epi16(r_xmm5, r_xmm7);
-        r_xmm5 = _mm_adds_epi16(r_xmm5, round_inv_col);
-        r_xmm6 = _mm_adds_epi16(r_xmm6, r_xmm3);
-        r_xmm6 = _mm_adds_epi16(r_xmm6, round_inv_col);
+        for (int n = 0; n < count; ++n)
+        {
+            const __m128i* data = reinterpret_cast<const __m128i *>(src);
+            const __m128i* qtable = reinterpret_cast<const __m128i *>(qt[idx]);
 
-        __m128i r0 = _mm_adds_epi16(r_xmm5, temp7);
-        __m128i r1 = _mm_adds_epi16(r_xmm6, r_xmm4);
-        __m128i r2 = _mm_adds_epi16(r_xmm1, r_xmm0);
-        __m128i r3 = _mm_adds_epi16(r_xmm2, temp3);
-        __m128i r4 = _mm_subs_epi16(r_xmm2, temp3);
-        __m128i r5 = _mm_subs_epi16(r_xmm1, r_xmm0);
-        __m128i r6 = _mm_subs_epi16(r_xmm6, r_xmm4);
-        __m128i r7 = _mm_subs_epi16(r_xmm5, temp7);
+            // Load and dequantize
+            __m128i v0 = _mm_mullo_epi16(data[0], qtable[0]);
+            __m128i v1 = _mm_mullo_epi16(data[1], qtable[1]);
+            __m128i v2 = _mm_mullo_epi16(data[2], qtable[2]);
+            __m128i v3 = _mm_mullo_epi16(data[3], qtable[3]);
+            __m128i v4 = _mm_mullo_epi16(data[4], qtable[4]);
+            __m128i v5 = _mm_mullo_epi16(data[5], qtable[5]);
+            __m128i v6 = _mm_mullo_epi16(data[6], qtable[6]);
+            __m128i v7 = _mm_mullo_epi16(data[7], qtable[7]);
 
-        r0 = _mm_srai_epi16(r0, 5);
-        r1 = _mm_srai_epi16(r1, 5);
-        r2 = _mm_srai_epi16(r2, 5);
-        r3 = _mm_srai_epi16(r3, 5);
-        r4 = _mm_srai_epi16(r4, 5);
-        r5 = _mm_srai_epi16(r5, 5);
-        r6 = _mm_srai_epi16(r6, 5);
-        r7 = _mm_srai_epi16(r7, 5);
+            __m128i r_xmm0, r_xmm1, r_xmm2, r_xmm3, r_xmm4, r_xmm5, r_xmm6, r_xmm7;
+            __m128i row0, row1, row2, row3, row4, row5, row6, row7;
 
-        __m128i s0 = _mm_packus_epi16(r0, r1);
-        __m128i s1 = _mm_packus_epi16(r2, r3);
-        __m128i s2 = _mm_packus_epi16(r4, r5);
-        __m128i s3 = _mm_packus_epi16(r6, r7);
+            // row 1 and Row 3
 
-        // store
-        __m128i* d = reinterpret_cast<__m128i *>(dest);
-        _mm_storeu_si128(d + 0, s0);
-        _mm_storeu_si128(d + 1, s1);
-        _mm_storeu_si128(d + 2, s2);
-        _mm_storeu_si128(d + 3, s3);
+            r_xmm0 = _mm_shufflelo_epi16(v0, 0xd8);
+            r_xmm1 = _mm_shuffle_epi32(r_xmm0, 0x00);
+            r_xmm1 = _mm_madd_epi16(r_xmm1, table04[0]);
+            r_xmm3 = _mm_shuffle_epi32(r_xmm0, 0x55);
+            r_xmm0 = _mm_shufflehi_epi16(r_xmm0, 0xd8);
+            r_xmm3 = _mm_madd_epi16(r_xmm3, table04[2]);
+            r_xmm2 = _mm_shuffle_epi32(r_xmm0, 0xaa);
+            r_xmm0 = _mm_shuffle_epi32(r_xmm0, 0xff);
+            r_xmm2 = _mm_madd_epi16(r_xmm2, table04[1]);
+
+            r_xmm4 = _mm_shufflehi_epi16(v2, 0xd8);
+            r_xmm1 = _mm_add_epi32(r_xmm1, round_inv_row);
+            r_xmm4 = _mm_shufflelo_epi16(r_xmm4, 0xd8);
+            r_xmm0 = _mm_madd_epi16(r_xmm0, table04[3]);
+            r_xmm5 = _mm_shuffle_epi32(r_xmm4, 0x00);
+            r_xmm6 = _mm_shuffle_epi32(r_xmm4, 0xaa);
+            r_xmm5 = _mm_madd_epi16(r_xmm5, table26[0]);
+            r_xmm1 = _mm_add_epi32(r_xmm1, r_xmm2);
+            r_xmm7 = _mm_shuffle_epi32(r_xmm4, 0x55);
+            r_xmm6 = _mm_madd_epi16(r_xmm6, table26[1]);
+            r_xmm0 = _mm_add_epi32(r_xmm0, r_xmm3);
+            r_xmm4 = _mm_shuffle_epi32(r_xmm4, 0xff);
+            r_xmm2 = _mm_sub_epi32(r_xmm1, r_xmm0);
+            r_xmm7 = _mm_madd_epi16(r_xmm7, table26[2]);
+            r_xmm0 = _mm_add_epi32(r_xmm0, r_xmm1);
+            r_xmm2 = _mm_srai_epi32(r_xmm2, 12);
+            r_xmm5 = _mm_add_epi32(r_xmm5, round_inv_row);
+            r_xmm4 = _mm_madd_epi16(r_xmm4, table26[3]);
+            r_xmm5 = _mm_add_epi32(r_xmm5, r_xmm6);
+            r_xmm0 = _mm_srai_epi32(r_xmm0, 12);
+            r_xmm2 = _mm_shuffle_epi32(r_xmm2, 0x1b);
+            row0 = _mm_packs_epi32(r_xmm0, r_xmm2);
+
+            r_xmm4 = _mm_add_epi32(r_xmm4, r_xmm7);
+            r_xmm6 = _mm_sub_epi32(r_xmm5, r_xmm4);
+            r_xmm4 = _mm_add_epi32(r_xmm4, r_xmm5);
+            r_xmm6 = _mm_srai_epi32(r_xmm6, 12);
+            r_xmm4 = _mm_srai_epi32(r_xmm4, 12);
+            r_xmm6 = _mm_shuffle_epi32(r_xmm6, 0x1b);
+            row2 = _mm_packs_epi32(r_xmm4, r_xmm6);
+
+            // row 5 and row 7
+
+            r_xmm0 = _mm_shufflelo_epi16(v4, 0xd8);
+            r_xmm1 = _mm_shuffle_epi32(r_xmm0, 0x00);
+            r_xmm1 = _mm_madd_epi16(r_xmm1, table04[0]);
+            r_xmm3 = _mm_shuffle_epi32(r_xmm0, 0x55);
+            r_xmm0 = _mm_shufflehi_epi16(r_xmm0, 0xd8);
+            r_xmm3 = _mm_madd_epi16(r_xmm3, table04[2]);
+            r_xmm2 = _mm_shuffle_epi32(r_xmm0, 0xaa);
+            r_xmm0 = _mm_shuffle_epi32(r_xmm0, 0xff);
+            r_xmm2 = _mm_madd_epi16(r_xmm2, table04[1]);
+            r_xmm4 = _mm_shufflehi_epi16(v6, 0xd8);
+            r_xmm1 = _mm_add_epi32(r_xmm1, round_inv_row);
+            r_xmm4 = _mm_shufflelo_epi16(r_xmm4, 0xd8);
+            r_xmm0 = _mm_madd_epi16(r_xmm0, table04[3]);
+            r_xmm5 = _mm_shuffle_epi32(r_xmm4, 0x00);
+            r_xmm6 = _mm_shuffle_epi32(r_xmm4, 0xaa);
+            r_xmm5 = _mm_madd_epi16(r_xmm5, table26[0]);
+            r_xmm1 = _mm_add_epi32(r_xmm1, r_xmm2);
+            r_xmm7 = _mm_shuffle_epi32(r_xmm4, 0x55);
+            r_xmm6 = _mm_madd_epi16(r_xmm6, table26[1]);
+            r_xmm0 = _mm_add_epi32(r_xmm0, r_xmm3);
+            r_xmm4 = _mm_shuffle_epi32(r_xmm4, 0xff);
+            r_xmm2 = _mm_sub_epi32(r_xmm1, r_xmm0);
+            r_xmm7 = _mm_madd_epi16(r_xmm7, table26[2]);
+            r_xmm0 = _mm_add_epi32(r_xmm0, r_xmm1);
+            r_xmm2 = _mm_srai_epi32(r_xmm2, 12);
+            r_xmm5 = _mm_add_epi32(r_xmm5, round_inv_row);
+            r_xmm4 = _mm_madd_epi16(r_xmm4, table26[3]);
+            r_xmm5 = _mm_add_epi32(r_xmm5, r_xmm6);
+            r_xmm0 = _mm_srai_epi32(r_xmm0, 12);
+            r_xmm2 = _mm_shuffle_epi32(r_xmm2, 0x1b);
+            row4 = _mm_packs_epi32(r_xmm0, r_xmm2);
+
+            r_xmm4 = _mm_add_epi32(r_xmm4, r_xmm7);
+            r_xmm6 = _mm_sub_epi32(r_xmm5, r_xmm4);
+            r_xmm4 = _mm_add_epi32(r_xmm4, r_xmm5);
+            r_xmm6 = _mm_srai_epi32(r_xmm6, 12);
+            r_xmm4 = _mm_srai_epi32(r_xmm4, 12);
+            r_xmm6 = _mm_shuffle_epi32(r_xmm6, 0x1b);
+            row6 = _mm_packs_epi32(r_xmm4, r_xmm6);
+
+            // row 4 and row 2
+
+            r_xmm0 = _mm_shufflelo_epi16(v3, 0xd8);
+            r_xmm1 = _mm_shuffle_epi32(r_xmm0, 0x00);
+            r_xmm1 = _mm_madd_epi16(r_xmm1, table35[0]);
+            r_xmm3 = _mm_shuffle_epi32(r_xmm0, 0x55);
+            r_xmm0 = _mm_shufflehi_epi16(r_xmm0, 0xd8);
+            r_xmm3 = _mm_madd_epi16(r_xmm3, table35[2]);
+            r_xmm2 = _mm_shuffle_epi32(r_xmm0, 0xaa);
+            r_xmm0 = _mm_shuffle_epi32(r_xmm0, 0xff);
+            r_xmm2 = _mm_madd_epi16(r_xmm2, table35[1]);
+            r_xmm4 = _mm_shufflehi_epi16(v1, 0xd8);
+            r_xmm1 = _mm_add_epi32(r_xmm1, round_inv_row);
+            r_xmm4 = _mm_shufflelo_epi16(r_xmm4, 0xd8);
+            r_xmm0 = _mm_madd_epi16(r_xmm0, table35[3]);
+            r_xmm5 = _mm_shuffle_epi32(r_xmm4, 0x00);
+            r_xmm6 = _mm_shuffle_epi32(r_xmm4, 0xaa);
+            r_xmm5 = _mm_madd_epi16(r_xmm5, table17[0]);
+            r_xmm1 = _mm_add_epi32(r_xmm1, r_xmm2);
+            r_xmm7 = _mm_shuffle_epi32(r_xmm4, 0x55);
+            r_xmm6 = _mm_madd_epi16(r_xmm6, table17[1]);
+            r_xmm0 = _mm_add_epi32(r_xmm0, r_xmm3);
+            r_xmm4 = _mm_shuffle_epi32(r_xmm4, 0xff);
+            r_xmm2 = _mm_sub_epi32(r_xmm1, r_xmm0);
+            r_xmm7 = _mm_madd_epi16(r_xmm7, table17[2]);
+            r_xmm0 = _mm_add_epi32(r_xmm0, r_xmm1);
+            r_xmm2 = _mm_srai_epi32(r_xmm2, 12);
+            r_xmm5 = _mm_add_epi32(r_xmm5, round_inv_row);
+            r_xmm4 = _mm_madd_epi16(r_xmm4, table17[3]);
+            r_xmm5 = _mm_add_epi32(r_xmm5, r_xmm6);
+            r_xmm0 = _mm_srai_epi32(r_xmm0, 12);
+            r_xmm2 = _mm_shuffle_epi32(r_xmm2, 0x1b);
+            row3 = _mm_packs_epi32(r_xmm0, r_xmm2);
+
+            r_xmm4 = _mm_add_epi32(r_xmm4, r_xmm7);
+            r_xmm6 = _mm_sub_epi32(r_xmm5, r_xmm4);
+            r_xmm4 = _mm_add_epi32(r_xmm5, r_xmm4);
+            r_xmm6 = _mm_srai_epi32(r_xmm6, 12);
+            r_xmm4 = _mm_srai_epi32(r_xmm4, 12);
+            r_xmm6 = _mm_shuffle_epi32(r_xmm6, 0x1b);
+            row1 = _mm_packs_epi32(r_xmm4, r_xmm6);
+
+            // row 6 and row 8
+
+            r_xmm0 = _mm_shufflelo_epi16(v5, 0xd8);
+            r_xmm1 = _mm_shuffle_epi32(r_xmm0, 0x00);
+            r_xmm1 = _mm_madd_epi16(r_xmm1, table35[0]);
+            r_xmm3 = _mm_shuffle_epi32(r_xmm0, 0x55);
+            r_xmm0 = _mm_shufflehi_epi16(r_xmm0, 0xd8);
+            r_xmm3 = _mm_madd_epi16(r_xmm3, table35[2]);
+            r_xmm2 = _mm_shuffle_epi32(r_xmm0, 0xaa);
+            r_xmm0 = _mm_shuffle_epi32(r_xmm0, 0xff);
+            r_xmm2 = _mm_madd_epi16(r_xmm2, table35[1]);
+            r_xmm4 = _mm_shufflehi_epi16(v7, 0xd8);
+            r_xmm1 = _mm_add_epi32(r_xmm1, round_inv_row);
+            r_xmm4 = _mm_shufflelo_epi16(r_xmm4, 0xd8);
+            r_xmm0 = _mm_madd_epi16(r_xmm0, table35[3]);
+            r_xmm5 = _mm_shuffle_epi32(r_xmm4, 0x00);
+            r_xmm6 = _mm_shuffle_epi32(r_xmm4, 0xaa);
+            r_xmm5 = _mm_madd_epi16(r_xmm5, table17[0]);
+            r_xmm1 = _mm_add_epi32(r_xmm1, r_xmm2);
+            r_xmm7 = _mm_shuffle_epi32(r_xmm4, 0x55);
+            r_xmm6 = _mm_madd_epi16(r_xmm6, table17[1]);
+            r_xmm0 = _mm_add_epi32(r_xmm0, r_xmm3);
+            r_xmm4 = _mm_shuffle_epi32(r_xmm4, 0xff);
+            r_xmm2 = _mm_sub_epi32(r_xmm1, r_xmm0);
+            r_xmm7 = _mm_madd_epi16(r_xmm7, table17[2]);
+            r_xmm0 = _mm_add_epi32(r_xmm0, r_xmm1);
+            r_xmm2 = _mm_srai_epi32(r_xmm2, 12);
+            r_xmm5 = _mm_add_epi32(r_xmm5, round_inv_row);
+            r_xmm4 = _mm_madd_epi16(r_xmm4, table17[3]);
+            r_xmm5 = _mm_add_epi32(r_xmm5, r_xmm6);
+            r_xmm0 = _mm_srai_epi32(r_xmm0, 12);
+            r_xmm2 = _mm_shuffle_epi32(r_xmm2, 0x1b);
+            row5 = _mm_packs_epi32(r_xmm0, r_xmm2);
+
+            r_xmm4 = _mm_add_epi32(r_xmm4, r_xmm7);
+            r_xmm6 = _mm_sub_epi32(r_xmm5, r_xmm4);
+            r_xmm4 = _mm_add_epi32(r_xmm5, r_xmm4);
+            r_xmm6 = _mm_srai_epi32(r_xmm6, 12);
+            r_xmm4 = _mm_srai_epi32(r_xmm4, 12);
+            r_xmm6 = _mm_shuffle_epi32(r_xmm6, 0x1b);
+            row7 = _mm_packs_epi32(r_xmm4, r_xmm6);
+
+            r_xmm1 = _mm_shuffle_epi32(tg, 0xaa);
+            r_xmm0 = _mm_mulhi_epi16(r_xmm1, row5);
+            r_xmm1 = _mm_mulhi_epi16(r_xmm1, row3);
+            r_xmm5 = _mm_shuffle_epi32(tg, 0x00);
+            r_xmm4 = _mm_mulhi_epi16(r_xmm5, row7);
+            r_xmm5 = _mm_mulhi_epi16(r_xmm5, row1);
+            r_xmm0 = _mm_adds_epi16(r_xmm0, row5);
+            r_xmm1 = _mm_adds_epi16(r_xmm1, row3);
+            r_xmm0 = _mm_adds_epi16(r_xmm0, row3);
+            r_xmm3 = _mm_shuffle_epi32(tg, 0x55);
+            r_xmm7 = _mm_mulhi_epi16(r_xmm3, row6);
+            r_xmm3 = _mm_mulhi_epi16(r_xmm3, row2);
+            r_xmm5 = _mm_subs_epi16(r_xmm5, row7);
+            r_xmm4 = _mm_adds_epi16(r_xmm4, row1);
+            r_xmm2 = _mm_subs_epi16(r_xmm2, r_xmm1);
+            r_xmm1 = _mm_adds_epi16(r_xmm0, r_xmm4);
+            r_xmm1 = _mm_adds_epi16(r_xmm1, one);
+            r_xmm4 = _mm_subs_epi16(r_xmm4, r_xmm0);
+            r_xmm6 = _mm_adds_epi16(r_xmm5, r_xmm2);
+            r_xmm5 = _mm_subs_epi16(r_xmm5, r_xmm2);
+            r_xmm5 = _mm_adds_epi16(r_xmm5, one);
+
+            __m128i temp7 = r_xmm1;
+            __m128i temp3 = r_xmm6;
+
+            r_xmm0 = _mm_shuffle_epi32(tg, 0xff);
+            r_xmm1 = _mm_subs_epi16(r_xmm4, r_xmm5);
+            r_xmm4 = _mm_adds_epi16(r_xmm4, r_xmm5);
+            r_xmm2 = _mm_mulhi_epi16(r_xmm0, r_xmm4);
+            r_xmm7 = _mm_adds_epi16(r_xmm7, row2);
+            r_xmm3 = _mm_subs_epi16(r_xmm3, row6);
+            r_xmm0 = _mm_mulhi_epi16(r_xmm0, r_xmm1);
+            r_xmm0 = _mm_adds_epi16(r_xmm0, r_xmm1);
+            r_xmm5 = _mm_adds_epi16(row0, row4);
+            r_xmm6 = _mm_subs_epi16(row0, row4);
+            r_xmm4 = _mm_adds_epi16(r_xmm4, r_xmm2);
+
+            r_xmm4 = _mm_or_si128(r_xmm4, one);
+            r_xmm0 = _mm_or_si128(r_xmm0, one);
+
+            r_xmm1 = _mm_subs_epi16(r_xmm6, r_xmm3);
+            r_xmm1 = _mm_adds_epi16(r_xmm1, round_inv_corr);
+            r_xmm2 = _mm_subs_epi16(r_xmm5, r_xmm7);
+            r_xmm2 = _mm_adds_epi16(r_xmm2, round_inv_corr);
+            r_xmm5 = _mm_adds_epi16(r_xmm5, r_xmm7);
+            r_xmm5 = _mm_adds_epi16(r_xmm5, round_inv_col);
+            r_xmm6 = _mm_adds_epi16(r_xmm6, r_xmm3);
+            r_xmm6 = _mm_adds_epi16(r_xmm6, round_inv_col);
+
+            __m128i r0 = _mm_adds_epi16(r_xmm5, temp7);
+            __m128i r1 = _mm_adds_epi16(r_xmm6, r_xmm4);
+            __m128i r2 = _mm_adds_epi16(r_xmm1, r_xmm0);
+            __m128i r3 = _mm_adds_epi16(r_xmm2, temp3);
+            __m128i r4 = _mm_subs_epi16(r_xmm2, temp3);
+            __m128i r5 = _mm_subs_epi16(r_xmm1, r_xmm0);
+            __m128i r6 = _mm_subs_epi16(r_xmm6, r_xmm4);
+            __m128i r7 = _mm_subs_epi16(r_xmm5, temp7);
+
+            r0 = _mm_srai_epi16(r0, 5);
+            r1 = _mm_srai_epi16(r1, 5);
+            r2 = _mm_srai_epi16(r2, 5);
+            r3 = _mm_srai_epi16(r3, 5);
+            r4 = _mm_srai_epi16(r4, 5);
+            r5 = _mm_srai_epi16(r5, 5);
+            r6 = _mm_srai_epi16(r6, 5);
+            r7 = _mm_srai_epi16(r7, 5);
+
+            __m128i s0 = _mm_packus_epi16(r0, r1);
+            __m128i s1 = _mm_packus_epi16(r2, r3);
+            __m128i s2 = _mm_packus_epi16(r4, r5);
+            __m128i s3 = _mm_packus_epi16(r6, r7);
+
+            // store
+            __m128i* d = reinterpret_cast<__m128i *>(dest);
+            _mm_storeu_si128(d + 0, s0);
+            _mm_storeu_si128(d + 1, s1);
+            _mm_storeu_si128(d + 2, s2);
+            _mm_storeu_si128(d + 3, s3);
+
+            dest += 64;
+            src += 64;
+
+            if (++idx == blocks)
+            {
+                idx = 0;
+            }
+        }
+    }
+
+    void idct_sse2(u8* dest, const s16* src, const s16* qt)
+    {
+        const s16* q[2] = { qt, qt };
+        idct_sse2_n(dest, src, q, 1, 0, 1);
     }
 
 #if defined(MANGO_ENABLE_AVX2)
 
-    // Dual 8x8 iDCT: block A in the low 128-bit lane, block B in the high lane.
-    // Both blocks share the same quantization table (same block index in adjacent MCUs).
-    void idct_avx2(u8* dest0, u8* dest1, const s16* src0, const s16* src1, const s16* qt)
+    // Linear dual 8x8 iDCT: consecutive blocks in 128-bit lanes, fused dequant.
+    void idct_avx2(u8* dest, const s16* src, const s16* const* qt, int blocks, int idx, int count)
     {
-        const __m128i* data0 = reinterpret_cast<const __m128i *>(src0);
-        const __m128i* data1 = reinterpret_cast<const __m128i *>(src1);
-        const __m128i* qtable = reinterpret_cast<const __m128i *>(qt);
-
-        __m256i v0 = _mm256_mullo_epi16(_mm256_set_m128i(data1[0], data0[0]), _mm256_broadcastsi128_si256(qtable[0]));
-        __m256i v1 = _mm256_mullo_epi16(_mm256_set_m128i(data1[1], data0[1]), _mm256_broadcastsi128_si256(qtable[1]));
-        __m256i v2 = _mm256_mullo_epi16(_mm256_set_m128i(data1[2], data0[2]), _mm256_broadcastsi128_si256(qtable[2]));
-        __m256i v3 = _mm256_mullo_epi16(_mm256_set_m128i(data1[3], data0[3]), _mm256_broadcastsi128_si256(qtable[3]));
-        __m256i v4 = _mm256_mullo_epi16(_mm256_set_m128i(data1[4], data0[4]), _mm256_broadcastsi128_si256(qtable[4]));
-        __m256i v5 = _mm256_mullo_epi16(_mm256_set_m128i(data1[5], data0[5]), _mm256_broadcastsi128_si256(qtable[5]));
-        __m256i v6 = _mm256_mullo_epi16(_mm256_set_m128i(data1[6], data0[6]), _mm256_broadcastsi128_si256(qtable[6]));
-        __m256i v7 = _mm256_mullo_epi16(_mm256_set_m128i(data1[7], data0[7]), _mm256_broadcastsi128_si256(qtable[7]));
-
-        __m256i r_xmm0, r_xmm1, r_xmm2, r_xmm3, r_xmm4, r_xmm5, r_xmm6, r_xmm7;
-        __m256i row0, row1, row2, row3, row4, row5, row6, row7;
-
-        // row 1 and Row 3
-
         const __m128i* table04 = reinterpret_cast<const __m128i*>(shortM128_tab_i_04);
         const __m128i* table26 = reinterpret_cast<const __m128i*>(shortM128_tab_i_26);
-
-        r_xmm0 = _mm256_shufflelo_epi16(v0, 0xd8);
-        r_xmm1 = _mm256_shuffle_epi32(r_xmm0, 0x00);
-        r_xmm1 = _mm256_madd_epi16(r_xmm1, _mm256_broadcastsi128_si256(table04[0]));
-        r_xmm3 = _mm256_shuffle_epi32(r_xmm0, 0x55);
-        r_xmm0 = _mm256_shufflehi_epi16(r_xmm0, 0xd8);
-        r_xmm3 = _mm256_madd_epi16(r_xmm3, _mm256_broadcastsi128_si256(table04[2]));
-        r_xmm2 = _mm256_shuffle_epi32(r_xmm0, 0xaa);
-        r_xmm0 = _mm256_shuffle_epi32(r_xmm0, 0xff);
-        r_xmm2 = _mm256_madd_epi16(r_xmm2, _mm256_broadcastsi128_si256(table04[1]));
-
-        const __m256i round_inv_row = _mm256_set1_epi32(2048);
-
-        r_xmm4 = _mm256_shufflehi_epi16(v2, 0xd8);
-        r_xmm1 = _mm256_add_epi32(r_xmm1, round_inv_row);
-        r_xmm4 = _mm256_shufflelo_epi16(r_xmm4, 0xd8);
-        r_xmm0 = _mm256_madd_epi16(r_xmm0, _mm256_broadcastsi128_si256(table04[3]));
-        r_xmm5 = _mm256_shuffle_epi32(r_xmm4, 0x00);
-        r_xmm6 = _mm256_shuffle_epi32(r_xmm4, 0xaa);
-        r_xmm5 = _mm256_madd_epi16(r_xmm5, _mm256_broadcastsi128_si256(table26[0]));
-        r_xmm1 = _mm256_add_epi32(r_xmm1, r_xmm2);
-        r_xmm7 = _mm256_shuffle_epi32(r_xmm4, 0x55);
-        r_xmm6 = _mm256_madd_epi16(r_xmm6, _mm256_broadcastsi128_si256(table26[1]));
-        r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm3);
-        r_xmm4 = _mm256_shuffle_epi32(r_xmm4, 0xff);
-        r_xmm2 = _mm256_sub_epi32(r_xmm1, r_xmm0);
-        r_xmm7 = _mm256_madd_epi16(r_xmm7, _mm256_broadcastsi128_si256(table26[2]));
-        r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm1);
-        r_xmm2 = _mm256_srai_epi32(r_xmm2, 12);
-        r_xmm5 = _mm256_add_epi32(r_xmm5, round_inv_row);
-        r_xmm4 = _mm256_madd_epi16(r_xmm4, _mm256_broadcastsi128_si256(table26[3]));
-        r_xmm5 = _mm256_add_epi32(r_xmm5, r_xmm6);
-        r_xmm0 = _mm256_srai_epi32(r_xmm0, 12);
-        r_xmm2 = _mm256_shuffle_epi32(r_xmm2, 0x1b);
-        row0 = _mm256_packs_epi32(r_xmm0, r_xmm2);
-
-        r_xmm4 = _mm256_add_epi32(r_xmm4, r_xmm7);
-        r_xmm6 = _mm256_sub_epi32(r_xmm5, r_xmm4);
-        r_xmm4 = _mm256_add_epi32(r_xmm4, r_xmm5);
-        r_xmm6 = _mm256_srai_epi32(r_xmm6, 12);
-        r_xmm4 = _mm256_srai_epi32(r_xmm4, 12);
-        r_xmm6 = _mm256_shuffle_epi32(r_xmm6, 0x1b);
-        row2 = _mm256_packs_epi32(r_xmm4, r_xmm6);
-
-        // row 5 and row 7
-
-        r_xmm0 = _mm256_shufflelo_epi16(v4, 0xd8);
-        r_xmm1 = _mm256_shuffle_epi32(r_xmm0, 0x00);
-        r_xmm1 = _mm256_madd_epi16(r_xmm1, _mm256_broadcastsi128_si256(table04[0]));
-        r_xmm3 = _mm256_shuffle_epi32(r_xmm0, 0x55);
-        r_xmm0 = _mm256_shufflehi_epi16(r_xmm0, 0xd8);
-        r_xmm3 = _mm256_madd_epi16(r_xmm3, _mm256_broadcastsi128_si256(table04[2]));
-        r_xmm2 = _mm256_shuffle_epi32(r_xmm0, 0xaa);
-        r_xmm0 = _mm256_shuffle_epi32(r_xmm0, 0xff);
-        r_xmm2 = _mm256_madd_epi16(r_xmm2, _mm256_broadcastsi128_si256(table04[1]));
-        r_xmm4 = _mm256_shufflehi_epi16(v6, 0xd8);
-        r_xmm1 = _mm256_add_epi32(r_xmm1, round_inv_row);
-        r_xmm4 = _mm256_shufflelo_epi16(r_xmm4, 0xd8);
-        r_xmm0 = _mm256_madd_epi16(r_xmm0, _mm256_broadcastsi128_si256(table04[3]));
-        r_xmm5 = _mm256_shuffle_epi32(r_xmm4, 0x00);
-        r_xmm6 = _mm256_shuffle_epi32(r_xmm4, 0xaa);
-        r_xmm5 = _mm256_madd_epi16(r_xmm5, _mm256_broadcastsi128_si256(table26[0]));
-        r_xmm1 = _mm256_add_epi32(r_xmm1, r_xmm2);
-        r_xmm7 = _mm256_shuffle_epi32(r_xmm4, 0x55);
-        r_xmm6 = _mm256_madd_epi16(r_xmm6, _mm256_broadcastsi128_si256(table26[1]));
-        r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm3);
-        r_xmm4 = _mm256_shuffle_epi32(r_xmm4, 0xff);
-        r_xmm2 = _mm256_sub_epi32(r_xmm1, r_xmm0);
-        r_xmm7 = _mm256_madd_epi16(r_xmm7, _mm256_broadcastsi128_si256(table26[2]));
-        r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm1);
-        r_xmm2 = _mm256_srai_epi32(r_xmm2, 12);
-        r_xmm5 = _mm256_add_epi32(r_xmm5, round_inv_row);
-        r_xmm4 = _mm256_madd_epi16(r_xmm4, _mm256_broadcastsi128_si256(table26[3]));
-        r_xmm5 = _mm256_add_epi32(r_xmm5, r_xmm6);
-        r_xmm0 = _mm256_srai_epi32(r_xmm0, 12);
-        r_xmm2 = _mm256_shuffle_epi32(r_xmm2, 0x1b);
-        row4 = _mm256_packs_epi32(r_xmm0, r_xmm2);
-
-        r_xmm4 = _mm256_add_epi32(r_xmm4, r_xmm7);
-        r_xmm6 = _mm256_sub_epi32(r_xmm5, r_xmm4);
-        r_xmm4 = _mm256_add_epi32(r_xmm4, r_xmm5);
-        r_xmm6 = _mm256_srai_epi32(r_xmm6, 12);
-        r_xmm4 = _mm256_srai_epi32(r_xmm4, 12);
-        r_xmm6 = _mm256_shuffle_epi32(r_xmm6, 0x1b);
-        row6 = _mm256_packs_epi32(r_xmm4, r_xmm6);
-
-        // row 4 and row 2
-
         const __m128i* table35 = reinterpret_cast<const __m128i*>(shortM128_tab_i_35);
         const __m128i* table17 = reinterpret_cast<const __m128i*>(shortM128_tab_i_17);
-
-        r_xmm0 = _mm256_shufflelo_epi16(v3, 0xd8);
-        r_xmm1 = _mm256_shuffle_epi32(r_xmm0, 0x00);
-        r_xmm1 = _mm256_madd_epi16(r_xmm1, _mm256_broadcastsi128_si256(table35[0]));
-        r_xmm3 = _mm256_shuffle_epi32(r_xmm0, 0x55);
-        r_xmm0 = _mm256_shufflehi_epi16(r_xmm0, 0xd8);
-        r_xmm3 = _mm256_madd_epi16(r_xmm3, _mm256_broadcastsi128_si256(table35[2]));
-        r_xmm2 = _mm256_shuffle_epi32(r_xmm0, 0xaa);
-        r_xmm0 = _mm256_shuffle_epi32(r_xmm0, 0xff);
-        r_xmm2 = _mm256_madd_epi16(r_xmm2, _mm256_broadcastsi128_si256(table35[1]));
-        r_xmm4 = _mm256_shufflehi_epi16(v1, 0xd8);
-        r_xmm1 = _mm256_add_epi32(r_xmm1, round_inv_row);
-        r_xmm4 = _mm256_shufflelo_epi16(r_xmm4, 0xd8);
-        r_xmm0 = _mm256_madd_epi16(r_xmm0, _mm256_broadcastsi128_si256(table35[3]));
-        r_xmm5 = _mm256_shuffle_epi32(r_xmm4, 0x00);
-        r_xmm6 = _mm256_shuffle_epi32(r_xmm4, 0xaa);
-        r_xmm5 = _mm256_madd_epi16(r_xmm5, _mm256_broadcastsi128_si256(table17[0]));
-        r_xmm1 = _mm256_add_epi32(r_xmm1, r_xmm2);
-        r_xmm7 = _mm256_shuffle_epi32(r_xmm4, 0x55);
-        r_xmm6 = _mm256_madd_epi16(r_xmm6, _mm256_broadcastsi128_si256(table17[1]));
-        r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm3);
-        r_xmm4 = _mm256_shuffle_epi32(r_xmm4, 0xff);
-        r_xmm2 = _mm256_sub_epi32(r_xmm1, r_xmm0);
-        r_xmm7 = _mm256_madd_epi16(r_xmm7, _mm256_broadcastsi128_si256(table17[2]));
-        r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm1);
-        r_xmm2 = _mm256_srai_epi32(r_xmm2, 12);
-        r_xmm5 = _mm256_add_epi32(r_xmm5, round_inv_row);
-        r_xmm4 = _mm256_madd_epi16(r_xmm4, _mm256_broadcastsi128_si256(table17[3]));
-        r_xmm5 = _mm256_add_epi32(r_xmm5, r_xmm6);
-        r_xmm0 = _mm256_srai_epi32(r_xmm0, 12);
-        r_xmm2 = _mm256_shuffle_epi32(r_xmm2, 0x1b);
-        row3 = _mm256_packs_epi32(r_xmm0, r_xmm2);
-
-        r_xmm4 = _mm256_add_epi32(r_xmm4, r_xmm7);
-        r_xmm6 = _mm256_sub_epi32(r_xmm5, r_xmm4);
-        r_xmm4 = _mm256_add_epi32(r_xmm5, r_xmm4);
-        r_xmm6 = _mm256_srai_epi32(r_xmm6, 12);
-        r_xmm4 = _mm256_srai_epi32(r_xmm4, 12);
-        r_xmm6 = _mm256_shuffle_epi32(r_xmm6, 0x1b);
-        row1 = _mm256_packs_epi32(r_xmm4, r_xmm6);
-
-        // row 6 and row 8
-
-        r_xmm0 = _mm256_shufflelo_epi16(v5, 0xd8);
-        r_xmm1 = _mm256_shuffle_epi32(r_xmm0, 0x00);
-        r_xmm1 = _mm256_madd_epi16(r_xmm1, _mm256_broadcastsi128_si256(table35[0]));
-        r_xmm3 = _mm256_shuffle_epi32(r_xmm0, 0x55);
-        r_xmm0 = _mm256_shufflehi_epi16(r_xmm0, 0xd8);
-        r_xmm3 = _mm256_madd_epi16(r_xmm3, _mm256_broadcastsi128_si256(table35[2]));
-        r_xmm2 = _mm256_shuffle_epi32(r_xmm0, 0xaa);
-        r_xmm0 = _mm256_shuffle_epi32(r_xmm0, 0xff);
-        r_xmm2 = _mm256_madd_epi16(r_xmm2, _mm256_broadcastsi128_si256(table35[1]));
-        r_xmm4 = _mm256_shufflehi_epi16(v7, 0xd8);
-        r_xmm1 = _mm256_add_epi32(r_xmm1, round_inv_row);
-        r_xmm4 = _mm256_shufflelo_epi16(r_xmm4, 0xd8);
-        r_xmm0 = _mm256_madd_epi16(r_xmm0, _mm256_broadcastsi128_si256(table35[3]));
-        r_xmm5 = _mm256_shuffle_epi32(r_xmm4, 0x00);
-        r_xmm6 = _mm256_shuffle_epi32(r_xmm4, 0xaa);
-        r_xmm5 = _mm256_madd_epi16(r_xmm5, _mm256_broadcastsi128_si256(table17[0]));
-        r_xmm1 = _mm256_add_epi32(r_xmm1, r_xmm2);
-        r_xmm7 = _mm256_shuffle_epi32(r_xmm4, 0x55);
-        r_xmm6 = _mm256_madd_epi16(r_xmm6, _mm256_broadcastsi128_si256(table17[1]));
-        r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm3);
-        r_xmm4 = _mm256_shuffle_epi32(r_xmm4, 0xff);
-        r_xmm2 = _mm256_sub_epi32(r_xmm1, r_xmm0);
-        r_xmm7 = _mm256_madd_epi16(r_xmm7, _mm256_broadcastsi128_si256(table17[2]));
-        r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm1);
-        r_xmm2 = _mm256_srai_epi32(r_xmm2, 12);
-        r_xmm5 = _mm256_add_epi32(r_xmm5, round_inv_row);
-        r_xmm4 = _mm256_madd_epi16(r_xmm4, _mm256_broadcastsi128_si256(table17[3]));
-        r_xmm5 = _mm256_add_epi32(r_xmm5, r_xmm6);
-        r_xmm0 = _mm256_srai_epi32(r_xmm0, 12);
-        r_xmm2 = _mm256_shuffle_epi32(r_xmm2, 0x1b);
-        row5 = _mm256_packs_epi32(r_xmm0, r_xmm2);
-
-        r_xmm4 = _mm256_add_epi32(r_xmm4, r_xmm7);
-        r_xmm6 = _mm256_sub_epi32(r_xmm5, r_xmm4);
-        r_xmm4 = _mm256_add_epi32(r_xmm5, r_xmm4);
-        r_xmm6 = _mm256_srai_epi32(r_xmm6, 12);
-        r_xmm4 = _mm256_srai_epi32(r_xmm4, 12);
-        r_xmm6 = _mm256_shuffle_epi32(r_xmm6, 0x1b);
-        row7 = _mm256_packs_epi32(r_xmm4, r_xmm6);
-
+        const __m256i round_inv_row = _mm256_set1_epi32(2048);
         const __m256i tg = _mm256_broadcastsi128_si256(_mm_set_epi16(-19195, -19195, -21746, -21746, 27146, 27146, 13036, 13036));
         const __m256i one = _mm256_set1_epi16(1);
-
-        r_xmm1 = _mm256_shuffle_epi32(tg, 0xaa);
-        r_xmm0 = _mm256_mulhi_epi16(r_xmm1, row5);
-        r_xmm1 = _mm256_mulhi_epi16(r_xmm1, row3);
-        r_xmm5 = _mm256_shuffle_epi32(tg, 0x00);
-        r_xmm4 = _mm256_mulhi_epi16(r_xmm5, row7);
-        r_xmm5 = _mm256_mulhi_epi16(r_xmm5, row1);
-        r_xmm0 = _mm256_adds_epi16(r_xmm0, row5);
-        r_xmm1 = _mm256_adds_epi16(r_xmm1, row3);
-        r_xmm0 = _mm256_adds_epi16(r_xmm0, row3);
-        r_xmm3 = _mm256_shuffle_epi32(tg, 0x55);
-        r_xmm7 = _mm256_mulhi_epi16(r_xmm3, row6);
-        r_xmm3 = _mm256_mulhi_epi16(r_xmm3, row2);
-        r_xmm5 = _mm256_subs_epi16(r_xmm5, row7);
-        r_xmm4 = _mm256_adds_epi16(r_xmm4, row1);
-        r_xmm2 = _mm256_subs_epi16(r_xmm2, r_xmm1);
-        r_xmm1 = _mm256_adds_epi16(r_xmm0, r_xmm4);
-        r_xmm1 = _mm256_adds_epi16(r_xmm1, one);
-        r_xmm4 = _mm256_subs_epi16(r_xmm4, r_xmm0);
-        r_xmm6 = _mm256_adds_epi16(r_xmm5, r_xmm2);
-        r_xmm5 = _mm256_subs_epi16(r_xmm5, r_xmm2);
-        r_xmm5 = _mm256_adds_epi16(r_xmm5, one);
-
-        __m256i temp7 = r_xmm1;
-        __m256i temp3 = r_xmm6;
-
-        r_xmm0 = _mm256_shuffle_epi32(tg, 0xff);
-        r_xmm1 = _mm256_subs_epi16(r_xmm4, r_xmm5);
-        r_xmm4 = _mm256_adds_epi16(r_xmm4, r_xmm5);
-        r_xmm2 = _mm256_mulhi_epi16(r_xmm0, r_xmm4);
-        r_xmm7 = _mm256_adds_epi16(r_xmm7, row2);
-        r_xmm3 = _mm256_subs_epi16(r_xmm3, row6);
-        r_xmm0 = _mm256_mulhi_epi16(r_xmm0, r_xmm1);
-        r_xmm0 = _mm256_adds_epi16(r_xmm0, r_xmm1);
-        r_xmm5 = _mm256_adds_epi16(row0, row4);
-        r_xmm6 = _mm256_subs_epi16(row0, row4);
-        r_xmm4 = _mm256_adds_epi16(r_xmm4, r_xmm2);
-
-        r_xmm4 = _mm256_or_si256(r_xmm4, one);
-        r_xmm0 = _mm256_or_si256(r_xmm0, one);
-
         const s16 bias = 128 << 5;
         const __m256i round_inv_col = _mm256_set1_epi16(16 + bias);
         const __m256i round_inv_corr = _mm256_sub_epi16(round_inv_col, one);
 
-        r_xmm1 = _mm256_subs_epi16(r_xmm6, r_xmm3);
-        r_xmm1 = _mm256_adds_epi16(r_xmm1, round_inv_corr);
-        r_xmm2 = _mm256_subs_epi16(r_xmm5, r_xmm7);
-        r_xmm2 = _mm256_adds_epi16(r_xmm2, round_inv_corr);
-        r_xmm5 = _mm256_adds_epi16(r_xmm5, r_xmm7);
-        r_xmm5 = _mm256_adds_epi16(r_xmm5, round_inv_col);
-        r_xmm6 = _mm256_adds_epi16(r_xmm6, r_xmm3);
-        r_xmm6 = _mm256_adds_epi16(r_xmm6, round_inv_col);
+        for (int n = 0; n < count; n += 2)
+        {
+            const __m128i* data0 = reinterpret_cast<const __m128i *>(src + 0);
+            const __m128i* data1 = reinterpret_cast<const __m128i *>(src + 64);
+            const __m128i* q0 = reinterpret_cast<const __m128i *>(qt[idx + 0]);
+            const __m128i* q1 = reinterpret_cast<const __m128i *>(qt[idx + 1]);
 
-        __m256i r0 = _mm256_adds_epi16(r_xmm5, temp7);
-        __m256i r1 = _mm256_adds_epi16(r_xmm6, r_xmm4);
-        __m256i r2 = _mm256_adds_epi16(r_xmm1, r_xmm0);
-        __m256i r3 = _mm256_adds_epi16(r_xmm2, temp3);
-        __m256i r4 = _mm256_subs_epi16(r_xmm2, temp3);
-        __m256i r5 = _mm256_subs_epi16(r_xmm1, r_xmm0);
-        __m256i r6 = _mm256_subs_epi16(r_xmm6, r_xmm4);
-        __m256i r7 = _mm256_subs_epi16(r_xmm5, temp7);
+            __m256i v0 = _mm256_mullo_epi16(_mm256_set_m128i(data1[0], data0[0]), _mm256_set_m128i(q1[0], q0[0]));
+            __m256i v1 = _mm256_mullo_epi16(_mm256_set_m128i(data1[1], data0[1]), _mm256_set_m128i(q1[1], q0[1]));
+            __m256i v2 = _mm256_mullo_epi16(_mm256_set_m128i(data1[2], data0[2]), _mm256_set_m128i(q1[2], q0[2]));
+            __m256i v3 = _mm256_mullo_epi16(_mm256_set_m128i(data1[3], data0[3]), _mm256_set_m128i(q1[3], q0[3]));
+            __m256i v4 = _mm256_mullo_epi16(_mm256_set_m128i(data1[4], data0[4]), _mm256_set_m128i(q1[4], q0[4]));
+            __m256i v5 = _mm256_mullo_epi16(_mm256_set_m128i(data1[5], data0[5]), _mm256_set_m128i(q1[5], q0[5]));
+            __m256i v6 = _mm256_mullo_epi16(_mm256_set_m128i(data1[6], data0[6]), _mm256_set_m128i(q1[6], q0[6]));
+            __m256i v7 = _mm256_mullo_epi16(_mm256_set_m128i(data1[7], data0[7]), _mm256_set_m128i(q1[7], q0[7]));
 
-        r0 = _mm256_srai_epi16(r0, 5);
-        r1 = _mm256_srai_epi16(r1, 5);
-        r2 = _mm256_srai_epi16(r2, 5);
-        r3 = _mm256_srai_epi16(r3, 5);
-        r4 = _mm256_srai_epi16(r4, 5);
-        r5 = _mm256_srai_epi16(r5, 5);
-        r6 = _mm256_srai_epi16(r6, 5);
-        r7 = _mm256_srai_epi16(r7, 5);
+            __m256i r_xmm0, r_xmm1, r_xmm2, r_xmm3, r_xmm4, r_xmm5, r_xmm6, r_xmm7;
+            __m256i row0, row1, row2, row3, row4, row5, row6, row7;
 
-        __m256i s0 = _mm256_packus_epi16(r0, r1);
-        __m256i s1 = _mm256_packus_epi16(r2, r3);
-        __m256i s2 = _mm256_packus_epi16(r4, r5);
-        __m256i s3 = _mm256_packus_epi16(r6, r7);
+            // row 1 and Row 3
 
+            r_xmm0 = _mm256_shufflelo_epi16(v0, 0xd8);
+            r_xmm1 = _mm256_shuffle_epi32(r_xmm0, 0x00);
+            r_xmm1 = _mm256_madd_epi16(r_xmm1, _mm256_broadcastsi128_si256(table04[0]));
+            r_xmm3 = _mm256_shuffle_epi32(r_xmm0, 0x55);
+            r_xmm0 = _mm256_shufflehi_epi16(r_xmm0, 0xd8);
+            r_xmm3 = _mm256_madd_epi16(r_xmm3, _mm256_broadcastsi128_si256(table04[2]));
+            r_xmm2 = _mm256_shuffle_epi32(r_xmm0, 0xaa);
+            r_xmm0 = _mm256_shuffle_epi32(r_xmm0, 0xff);
+            r_xmm2 = _mm256_madd_epi16(r_xmm2, _mm256_broadcastsi128_si256(table04[1]));
 
-        // store: low lane -> dest0, high lane -> dest1
-        _mm256_storeu2_m128i(reinterpret_cast<__m128i *>(dest1) + 0,
-                             reinterpret_cast<__m128i *>(dest0) + 0, s0);
-        _mm256_storeu2_m128i(reinterpret_cast<__m128i *>(dest1) + 1,
-                             reinterpret_cast<__m128i *>(dest0) + 1, s1);
-        _mm256_storeu2_m128i(reinterpret_cast<__m128i *>(dest1) + 2,
-                             reinterpret_cast<__m128i *>(dest0) + 2, s2);
-        _mm256_storeu2_m128i(reinterpret_cast<__m128i *>(dest1) + 3,
-                             reinterpret_cast<__m128i *>(dest0) + 3, s3);
+            r_xmm4 = _mm256_shufflehi_epi16(v2, 0xd8);
+            r_xmm1 = _mm256_add_epi32(r_xmm1, round_inv_row);
+            r_xmm4 = _mm256_shufflelo_epi16(r_xmm4, 0xd8);
+            r_xmm0 = _mm256_madd_epi16(r_xmm0, _mm256_broadcastsi128_si256(table04[3]));
+            r_xmm5 = _mm256_shuffle_epi32(r_xmm4, 0x00);
+            r_xmm6 = _mm256_shuffle_epi32(r_xmm4, 0xaa);
+            r_xmm5 = _mm256_madd_epi16(r_xmm5, _mm256_broadcastsi128_si256(table26[0]));
+            r_xmm1 = _mm256_add_epi32(r_xmm1, r_xmm2);
+            r_xmm7 = _mm256_shuffle_epi32(r_xmm4, 0x55);
+            r_xmm6 = _mm256_madd_epi16(r_xmm6, _mm256_broadcastsi128_si256(table26[1]));
+            r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm3);
+            r_xmm4 = _mm256_shuffle_epi32(r_xmm4, 0xff);
+            r_xmm2 = _mm256_sub_epi32(r_xmm1, r_xmm0);
+            r_xmm7 = _mm256_madd_epi16(r_xmm7, _mm256_broadcastsi128_si256(table26[2]));
+            r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm1);
+            r_xmm2 = _mm256_srai_epi32(r_xmm2, 12);
+            r_xmm5 = _mm256_add_epi32(r_xmm5, round_inv_row);
+            r_xmm4 = _mm256_madd_epi16(r_xmm4, _mm256_broadcastsi128_si256(table26[3]));
+            r_xmm5 = _mm256_add_epi32(r_xmm5, r_xmm6);
+            r_xmm0 = _mm256_srai_epi32(r_xmm0, 12);
+            r_xmm2 = _mm256_shuffle_epi32(r_xmm2, 0x1b);
+            row0 = _mm256_packs_epi32(r_xmm0, r_xmm2);
+
+            r_xmm4 = _mm256_add_epi32(r_xmm4, r_xmm7);
+            r_xmm6 = _mm256_sub_epi32(r_xmm5, r_xmm4);
+            r_xmm4 = _mm256_add_epi32(r_xmm4, r_xmm5);
+            r_xmm6 = _mm256_srai_epi32(r_xmm6, 12);
+            r_xmm4 = _mm256_srai_epi32(r_xmm4, 12);
+            r_xmm6 = _mm256_shuffle_epi32(r_xmm6, 0x1b);
+            row2 = _mm256_packs_epi32(r_xmm4, r_xmm6);
+
+            // row 5 and row 7
+
+            r_xmm0 = _mm256_shufflelo_epi16(v4, 0xd8);
+            r_xmm1 = _mm256_shuffle_epi32(r_xmm0, 0x00);
+            r_xmm1 = _mm256_madd_epi16(r_xmm1, _mm256_broadcastsi128_si256(table04[0]));
+            r_xmm3 = _mm256_shuffle_epi32(r_xmm0, 0x55);
+            r_xmm0 = _mm256_shufflehi_epi16(r_xmm0, 0xd8);
+            r_xmm3 = _mm256_madd_epi16(r_xmm3, _mm256_broadcastsi128_si256(table04[2]));
+            r_xmm2 = _mm256_shuffle_epi32(r_xmm0, 0xaa);
+            r_xmm0 = _mm256_shuffle_epi32(r_xmm0, 0xff);
+            r_xmm2 = _mm256_madd_epi16(r_xmm2, _mm256_broadcastsi128_si256(table04[1]));
+            r_xmm4 = _mm256_shufflehi_epi16(v6, 0xd8);
+            r_xmm1 = _mm256_add_epi32(r_xmm1, round_inv_row);
+            r_xmm4 = _mm256_shufflelo_epi16(r_xmm4, 0xd8);
+            r_xmm0 = _mm256_madd_epi16(r_xmm0, _mm256_broadcastsi128_si256(table04[3]));
+            r_xmm5 = _mm256_shuffle_epi32(r_xmm4, 0x00);
+            r_xmm6 = _mm256_shuffle_epi32(r_xmm4, 0xaa);
+            r_xmm5 = _mm256_madd_epi16(r_xmm5, _mm256_broadcastsi128_si256(table26[0]));
+            r_xmm1 = _mm256_add_epi32(r_xmm1, r_xmm2);
+            r_xmm7 = _mm256_shuffle_epi32(r_xmm4, 0x55);
+            r_xmm6 = _mm256_madd_epi16(r_xmm6, _mm256_broadcastsi128_si256(table26[1]));
+            r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm3);
+            r_xmm4 = _mm256_shuffle_epi32(r_xmm4, 0xff);
+            r_xmm2 = _mm256_sub_epi32(r_xmm1, r_xmm0);
+            r_xmm7 = _mm256_madd_epi16(r_xmm7, _mm256_broadcastsi128_si256(table26[2]));
+            r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm1);
+            r_xmm2 = _mm256_srai_epi32(r_xmm2, 12);
+            r_xmm5 = _mm256_add_epi32(r_xmm5, round_inv_row);
+            r_xmm4 = _mm256_madd_epi16(r_xmm4, _mm256_broadcastsi128_si256(table26[3]));
+            r_xmm5 = _mm256_add_epi32(r_xmm5, r_xmm6);
+            r_xmm0 = _mm256_srai_epi32(r_xmm0, 12);
+            r_xmm2 = _mm256_shuffle_epi32(r_xmm2, 0x1b);
+            row4 = _mm256_packs_epi32(r_xmm0, r_xmm2);
+
+            r_xmm4 = _mm256_add_epi32(r_xmm4, r_xmm7);
+            r_xmm6 = _mm256_sub_epi32(r_xmm5, r_xmm4);
+            r_xmm4 = _mm256_add_epi32(r_xmm4, r_xmm5);
+            r_xmm6 = _mm256_srai_epi32(r_xmm6, 12);
+            r_xmm4 = _mm256_srai_epi32(r_xmm4, 12);
+            r_xmm6 = _mm256_shuffle_epi32(r_xmm6, 0x1b);
+            row6 = _mm256_packs_epi32(r_xmm4, r_xmm6);
+
+            // row 4 and row 2
+
+            r_xmm0 = _mm256_shufflelo_epi16(v3, 0xd8);
+            r_xmm1 = _mm256_shuffle_epi32(r_xmm0, 0x00);
+            r_xmm1 = _mm256_madd_epi16(r_xmm1, _mm256_broadcastsi128_si256(table35[0]));
+            r_xmm3 = _mm256_shuffle_epi32(r_xmm0, 0x55);
+            r_xmm0 = _mm256_shufflehi_epi16(r_xmm0, 0xd8);
+            r_xmm3 = _mm256_madd_epi16(r_xmm3, _mm256_broadcastsi128_si256(table35[2]));
+            r_xmm2 = _mm256_shuffle_epi32(r_xmm0, 0xaa);
+            r_xmm0 = _mm256_shuffle_epi32(r_xmm0, 0xff);
+            r_xmm2 = _mm256_madd_epi16(r_xmm2, _mm256_broadcastsi128_si256(table35[1]));
+            r_xmm4 = _mm256_shufflehi_epi16(v1, 0xd8);
+            r_xmm1 = _mm256_add_epi32(r_xmm1, round_inv_row);
+            r_xmm4 = _mm256_shufflelo_epi16(r_xmm4, 0xd8);
+            r_xmm0 = _mm256_madd_epi16(r_xmm0, _mm256_broadcastsi128_si256(table35[3]));
+            r_xmm5 = _mm256_shuffle_epi32(r_xmm4, 0x00);
+            r_xmm6 = _mm256_shuffle_epi32(r_xmm4, 0xaa);
+            r_xmm5 = _mm256_madd_epi16(r_xmm5, _mm256_broadcastsi128_si256(table17[0]));
+            r_xmm1 = _mm256_add_epi32(r_xmm1, r_xmm2);
+            r_xmm7 = _mm256_shuffle_epi32(r_xmm4, 0x55);
+            r_xmm6 = _mm256_madd_epi16(r_xmm6, _mm256_broadcastsi128_si256(table17[1]));
+            r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm3);
+            r_xmm4 = _mm256_shuffle_epi32(r_xmm4, 0xff);
+            r_xmm2 = _mm256_sub_epi32(r_xmm1, r_xmm0);
+            r_xmm7 = _mm256_madd_epi16(r_xmm7, _mm256_broadcastsi128_si256(table17[2]));
+            r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm1);
+            r_xmm2 = _mm256_srai_epi32(r_xmm2, 12);
+            r_xmm5 = _mm256_add_epi32(r_xmm5, round_inv_row);
+            r_xmm4 = _mm256_madd_epi16(r_xmm4, _mm256_broadcastsi128_si256(table17[3]));
+            r_xmm5 = _mm256_add_epi32(r_xmm5, r_xmm6);
+            r_xmm0 = _mm256_srai_epi32(r_xmm0, 12);
+            r_xmm2 = _mm256_shuffle_epi32(r_xmm2, 0x1b);
+            row3 = _mm256_packs_epi32(r_xmm0, r_xmm2);
+
+            r_xmm4 = _mm256_add_epi32(r_xmm4, r_xmm7);
+            r_xmm6 = _mm256_sub_epi32(r_xmm5, r_xmm4);
+            r_xmm4 = _mm256_add_epi32(r_xmm5, r_xmm4);
+            r_xmm6 = _mm256_srai_epi32(r_xmm6, 12);
+            r_xmm4 = _mm256_srai_epi32(r_xmm4, 12);
+            r_xmm6 = _mm256_shuffle_epi32(r_xmm6, 0x1b);
+            row1 = _mm256_packs_epi32(r_xmm4, r_xmm6);
+
+            // row 6 and row 8
+
+            r_xmm0 = _mm256_shufflelo_epi16(v5, 0xd8);
+            r_xmm1 = _mm256_shuffle_epi32(r_xmm0, 0x00);
+            r_xmm1 = _mm256_madd_epi16(r_xmm1, _mm256_broadcastsi128_si256(table35[0]));
+            r_xmm3 = _mm256_shuffle_epi32(r_xmm0, 0x55);
+            r_xmm0 = _mm256_shufflehi_epi16(r_xmm0, 0xd8);
+            r_xmm3 = _mm256_madd_epi16(r_xmm3, _mm256_broadcastsi128_si256(table35[2]));
+            r_xmm2 = _mm256_shuffle_epi32(r_xmm0, 0xaa);
+            r_xmm0 = _mm256_shuffle_epi32(r_xmm0, 0xff);
+            r_xmm2 = _mm256_madd_epi16(r_xmm2, _mm256_broadcastsi128_si256(table35[1]));
+            r_xmm4 = _mm256_shufflehi_epi16(v7, 0xd8);
+            r_xmm1 = _mm256_add_epi32(r_xmm1, round_inv_row);
+            r_xmm4 = _mm256_shufflelo_epi16(r_xmm4, 0xd8);
+            r_xmm0 = _mm256_madd_epi16(r_xmm0, _mm256_broadcastsi128_si256(table35[3]));
+            r_xmm5 = _mm256_shuffle_epi32(r_xmm4, 0x00);
+            r_xmm6 = _mm256_shuffle_epi32(r_xmm4, 0xaa);
+            r_xmm5 = _mm256_madd_epi16(r_xmm5, _mm256_broadcastsi128_si256(table17[0]));
+            r_xmm1 = _mm256_add_epi32(r_xmm1, r_xmm2);
+            r_xmm7 = _mm256_shuffle_epi32(r_xmm4, 0x55);
+            r_xmm6 = _mm256_madd_epi16(r_xmm6, _mm256_broadcastsi128_si256(table17[1]));
+            r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm3);
+            r_xmm4 = _mm256_shuffle_epi32(r_xmm4, 0xff);
+            r_xmm2 = _mm256_sub_epi32(r_xmm1, r_xmm0);
+            r_xmm7 = _mm256_madd_epi16(r_xmm7, _mm256_broadcastsi128_si256(table17[2]));
+            r_xmm0 = _mm256_add_epi32(r_xmm0, r_xmm1);
+            r_xmm2 = _mm256_srai_epi32(r_xmm2, 12);
+            r_xmm5 = _mm256_add_epi32(r_xmm5, round_inv_row);
+            r_xmm4 = _mm256_madd_epi16(r_xmm4, _mm256_broadcastsi128_si256(table17[3]));
+            r_xmm5 = _mm256_add_epi32(r_xmm5, r_xmm6);
+            r_xmm0 = _mm256_srai_epi32(r_xmm0, 12);
+            r_xmm2 = _mm256_shuffle_epi32(r_xmm2, 0x1b);
+            row5 = _mm256_packs_epi32(r_xmm0, r_xmm2);
+
+            r_xmm4 = _mm256_add_epi32(r_xmm4, r_xmm7);
+            r_xmm6 = _mm256_sub_epi32(r_xmm5, r_xmm4);
+            r_xmm4 = _mm256_add_epi32(r_xmm5, r_xmm4);
+            r_xmm6 = _mm256_srai_epi32(r_xmm6, 12);
+            r_xmm4 = _mm256_srai_epi32(r_xmm4, 12);
+            r_xmm6 = _mm256_shuffle_epi32(r_xmm6, 0x1b);
+            row7 = _mm256_packs_epi32(r_xmm4, r_xmm6);
+
+            r_xmm1 = _mm256_shuffle_epi32(tg, 0xaa);
+            r_xmm0 = _mm256_mulhi_epi16(r_xmm1, row5);
+            r_xmm1 = _mm256_mulhi_epi16(r_xmm1, row3);
+            r_xmm5 = _mm256_shuffle_epi32(tg, 0x00);
+            r_xmm4 = _mm256_mulhi_epi16(r_xmm5, row7);
+            r_xmm5 = _mm256_mulhi_epi16(r_xmm5, row1);
+            r_xmm0 = _mm256_adds_epi16(r_xmm0, row5);
+            r_xmm1 = _mm256_adds_epi16(r_xmm1, row3);
+            r_xmm0 = _mm256_adds_epi16(r_xmm0, row3);
+            r_xmm3 = _mm256_shuffle_epi32(tg, 0x55);
+            r_xmm7 = _mm256_mulhi_epi16(r_xmm3, row6);
+            r_xmm3 = _mm256_mulhi_epi16(r_xmm3, row2);
+            r_xmm5 = _mm256_subs_epi16(r_xmm5, row7);
+            r_xmm4 = _mm256_adds_epi16(r_xmm4, row1);
+            r_xmm2 = _mm256_subs_epi16(r_xmm2, r_xmm1);
+            r_xmm1 = _mm256_adds_epi16(r_xmm0, r_xmm4);
+            r_xmm1 = _mm256_adds_epi16(r_xmm1, one);
+            r_xmm4 = _mm256_subs_epi16(r_xmm4, r_xmm0);
+            r_xmm6 = _mm256_adds_epi16(r_xmm5, r_xmm2);
+            r_xmm5 = _mm256_subs_epi16(r_xmm5, r_xmm2);
+            r_xmm5 = _mm256_adds_epi16(r_xmm5, one);
+
+            __m256i temp7 = r_xmm1;
+            __m256i temp3 = r_xmm6;
+
+            r_xmm0 = _mm256_shuffle_epi32(tg, 0xff);
+            r_xmm1 = _mm256_subs_epi16(r_xmm4, r_xmm5);
+            r_xmm4 = _mm256_adds_epi16(r_xmm4, r_xmm5);
+            r_xmm2 = _mm256_mulhi_epi16(r_xmm0, r_xmm4);
+            r_xmm7 = _mm256_adds_epi16(r_xmm7, row2);
+            r_xmm3 = _mm256_subs_epi16(r_xmm3, row6);
+            r_xmm0 = _mm256_mulhi_epi16(r_xmm0, r_xmm1);
+            r_xmm0 = _mm256_adds_epi16(r_xmm0, r_xmm1);
+            r_xmm5 = _mm256_adds_epi16(row0, row4);
+            r_xmm6 = _mm256_subs_epi16(row0, row4);
+            r_xmm4 = _mm256_adds_epi16(r_xmm4, r_xmm2);
+
+            r_xmm4 = _mm256_or_si256(r_xmm4, one);
+            r_xmm0 = _mm256_or_si256(r_xmm0, one);
+
+            r_xmm1 = _mm256_subs_epi16(r_xmm6, r_xmm3);
+            r_xmm1 = _mm256_adds_epi16(r_xmm1, round_inv_corr);
+            r_xmm2 = _mm256_subs_epi16(r_xmm5, r_xmm7);
+            r_xmm2 = _mm256_adds_epi16(r_xmm2, round_inv_corr);
+            r_xmm5 = _mm256_adds_epi16(r_xmm5, r_xmm7);
+            r_xmm5 = _mm256_adds_epi16(r_xmm5, round_inv_col);
+            r_xmm6 = _mm256_adds_epi16(r_xmm6, r_xmm3);
+            r_xmm6 = _mm256_adds_epi16(r_xmm6, round_inv_col);
+
+            __m256i r0 = _mm256_adds_epi16(r_xmm5, temp7);
+            __m256i r1 = _mm256_adds_epi16(r_xmm6, r_xmm4);
+            __m256i r2 = _mm256_adds_epi16(r_xmm1, r_xmm0);
+            __m256i r3 = _mm256_adds_epi16(r_xmm2, temp3);
+            __m256i r4 = _mm256_subs_epi16(r_xmm2, temp3);
+            __m256i r5 = _mm256_subs_epi16(r_xmm1, r_xmm0);
+            __m256i r6 = _mm256_subs_epi16(r_xmm6, r_xmm4);
+            __m256i r7 = _mm256_subs_epi16(r_xmm5, temp7);
+
+            r0 = _mm256_srai_epi16(r0, 5);
+            r1 = _mm256_srai_epi16(r1, 5);
+            r2 = _mm256_srai_epi16(r2, 5);
+            r3 = _mm256_srai_epi16(r3, 5);
+            r4 = _mm256_srai_epi16(r4, 5);
+            r5 = _mm256_srai_epi16(r5, 5);
+            r6 = _mm256_srai_epi16(r6, 5);
+            r7 = _mm256_srai_epi16(r7, 5);
+
+            __m256i s0 = _mm256_packus_epi16(r0, r1);
+            __m256i s1 = _mm256_packus_epi16(r2, r3);
+            __m256i s2 = _mm256_packus_epi16(r4, r5);
+            __m256i s3 = _mm256_packus_epi16(r6, r7);
+
+            _mm256_storeu2_m128i(reinterpret_cast<__m128i *>(dest + 64) + 0,
+                                 reinterpret_cast<__m128i *>(dest) + 0, s0);
+            _mm256_storeu2_m128i(reinterpret_cast<__m128i *>(dest + 64) + 1,
+                                 reinterpret_cast<__m128i *>(dest) + 1, s1);
+            _mm256_storeu2_m128i(reinterpret_cast<__m128i *>(dest + 64) + 2,
+                                 reinterpret_cast<__m128i *>(dest) + 2, s2);
+            _mm256_storeu2_m128i(reinterpret_cast<__m128i *>(dest + 64) + 3,
+                                 reinterpret_cast<__m128i *>(dest) + 3, s3);
+
+            dest += 128;
+            src += 128;
+
+            idx += 2;
+            while (idx >= blocks)
+            {
+                idx -= blocks;
+            }
+        }
     }
 
 #endif // MANGO_ENABLE_AVX2
 
 #if defined(MANGO_ENABLE_AVX512)
 
-    // Quad 8x8 iDCT: blocks A,B,C,D in the four 128-bit lanes of a ZMM.
-    // All four blocks share the same quantization table (same block index in adjacent MCUs).
-    void idct_avx512(u8* dest0, u8* dest1, u8* dest2, u8* dest3,
-                     const s16* src0, const s16* src1, const s16* src2, const s16* src3, const s16* qt)
+    // Linear quad 8x8 iDCT: consecutive blocks in 128-bit lanes, fused dequant.
+    void idct_avx512(u8* dest, const s16* src, const s16* const* qt, int blocks, int idx, int count)
     {
-        const __m128i* data0 = reinterpret_cast<const __m128i *>(src0);
-        const __m128i* data1 = reinterpret_cast<const __m128i *>(src1);
-        const __m128i* data2 = reinterpret_cast<const __m128i *>(src2);
-        const __m128i* data3 = reinterpret_cast<const __m128i *>(src3);
-        const __m128i* qtable = reinterpret_cast<const __m128i *>(qt);
-
-        auto load4 = [&](int i) -> __m512i
-        {
-            return _mm512_inserti32x4(
-                _mm512_inserti32x4(
-                    _mm512_inserti32x4(_mm512_castsi128_si512(data0[i]), data1[i], 1),
-                    data2[i], 2),
-                data3[i], 3);
-        };
-
-        __m512i v0 = _mm512_mullo_epi16(load4(0), _mm512_broadcast_i32x4(qtable[0]));
-        __m512i v1 = _mm512_mullo_epi16(load4(1), _mm512_broadcast_i32x4(qtable[1]));
-        __m512i v2 = _mm512_mullo_epi16(load4(2), _mm512_broadcast_i32x4(qtable[2]));
-        __m512i v3 = _mm512_mullo_epi16(load4(3), _mm512_broadcast_i32x4(qtable[3]));
-        __m512i v4 = _mm512_mullo_epi16(load4(4), _mm512_broadcast_i32x4(qtable[4]));
-        __m512i v5 = _mm512_mullo_epi16(load4(5), _mm512_broadcast_i32x4(qtable[5]));
-        __m512i v6 = _mm512_mullo_epi16(load4(6), _mm512_broadcast_i32x4(qtable[6]));
-        __m512i v7 = _mm512_mullo_epi16(load4(7), _mm512_broadcast_i32x4(qtable[7]));
-
-        __m512i r_xmm0, r_xmm1, r_xmm2, r_xmm3, r_xmm4, r_xmm5, r_xmm6, r_xmm7;
-        __m512i row0, row1, row2, row3, row4, row5, row6, row7;
-
-        // row 1 and Row 3
-
         const __m128i* table04 = reinterpret_cast<const __m128i*>(shortM128_tab_i_04);
         const __m128i* table26 = reinterpret_cast<const __m128i*>(shortM128_tab_i_26);
-
-        r_xmm0 = _mm512_shufflelo_epi16(v0, 0xd8);
-        r_xmm1 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x00));
-        r_xmm1 = _mm512_madd_epi16(r_xmm1, _mm512_broadcast_i32x4(table04[0]));
-        r_xmm3 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x55));
-        r_xmm0 = _mm512_shufflehi_epi16(r_xmm0, 0xd8);
-        r_xmm3 = _mm512_madd_epi16(r_xmm3, _mm512_broadcast_i32x4(table04[2]));
-        r_xmm2 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xaa));
-        r_xmm0 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xff));
-        r_xmm2 = _mm512_madd_epi16(r_xmm2, _mm512_broadcast_i32x4(table04[1]));
-
-        const __m512i round_inv_row = _mm512_set1_epi32(2048);
-
-        r_xmm4 = _mm512_shufflehi_epi16(v2, 0xd8);
-        r_xmm1 = _mm512_add_epi32(r_xmm1, round_inv_row);
-        r_xmm4 = _mm512_shufflelo_epi16(r_xmm4, 0xd8);
-        r_xmm0 = _mm512_madd_epi16(r_xmm0, _mm512_broadcast_i32x4(table04[3]));
-        r_xmm5 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x00));
-        r_xmm6 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xaa));
-        r_xmm5 = _mm512_madd_epi16(r_xmm5, _mm512_broadcast_i32x4(table26[0]));
-        r_xmm1 = _mm512_add_epi32(r_xmm1, r_xmm2);
-        r_xmm7 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x55));
-        r_xmm6 = _mm512_madd_epi16(r_xmm6, _mm512_broadcast_i32x4(table26[1]));
-        r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm3);
-        r_xmm4 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xff));
-        r_xmm2 = _mm512_sub_epi32(r_xmm1, r_xmm0);
-        r_xmm7 = _mm512_madd_epi16(r_xmm7, _mm512_broadcast_i32x4(table26[2]));
-        r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm1);
-        r_xmm2 = _mm512_srai_epi32(r_xmm2, 12);
-        r_xmm5 = _mm512_add_epi32(r_xmm5, round_inv_row);
-        r_xmm4 = _mm512_madd_epi16(r_xmm4, _mm512_broadcast_i32x4(table26[3]));
-        r_xmm5 = _mm512_add_epi32(r_xmm5, r_xmm6);
-        r_xmm0 = _mm512_srai_epi32(r_xmm0, 12);
-        r_xmm2 = _mm512_shuffle_epi32(r_xmm2, (_MM_PERM_ENUM)(0x1b));
-        row0 = _mm512_packs_epi32(r_xmm0, r_xmm2);
-
-        r_xmm4 = _mm512_add_epi32(r_xmm4, r_xmm7);
-        r_xmm6 = _mm512_sub_epi32(r_xmm5, r_xmm4);
-        r_xmm4 = _mm512_add_epi32(r_xmm4, r_xmm5);
-        r_xmm6 = _mm512_srai_epi32(r_xmm6, 12);
-        r_xmm4 = _mm512_srai_epi32(r_xmm4, 12);
-        r_xmm6 = _mm512_shuffle_epi32(r_xmm6, (_MM_PERM_ENUM)(0x1b));
-        row2 = _mm512_packs_epi32(r_xmm4, r_xmm6);
-
-        // row 5 and row 7
-
-        r_xmm0 = _mm512_shufflelo_epi16(v4, 0xd8);
-        r_xmm1 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x00));
-        r_xmm1 = _mm512_madd_epi16(r_xmm1, _mm512_broadcast_i32x4(table04[0]));
-        r_xmm3 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x55));
-        r_xmm0 = _mm512_shufflehi_epi16(r_xmm0, 0xd8);
-        r_xmm3 = _mm512_madd_epi16(r_xmm3, _mm512_broadcast_i32x4(table04[2]));
-        r_xmm2 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xaa));
-        r_xmm0 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xff));
-        r_xmm2 = _mm512_madd_epi16(r_xmm2, _mm512_broadcast_i32x4(table04[1]));
-        r_xmm4 = _mm512_shufflehi_epi16(v6, 0xd8);
-        r_xmm1 = _mm512_add_epi32(r_xmm1, round_inv_row);
-        r_xmm4 = _mm512_shufflelo_epi16(r_xmm4, 0xd8);
-        r_xmm0 = _mm512_madd_epi16(r_xmm0, _mm512_broadcast_i32x4(table04[3]));
-        r_xmm5 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x00));
-        r_xmm6 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xaa));
-        r_xmm5 = _mm512_madd_epi16(r_xmm5, _mm512_broadcast_i32x4(table26[0]));
-        r_xmm1 = _mm512_add_epi32(r_xmm1, r_xmm2);
-        r_xmm7 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x55));
-        r_xmm6 = _mm512_madd_epi16(r_xmm6, _mm512_broadcast_i32x4(table26[1]));
-        r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm3);
-        r_xmm4 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xff));
-        r_xmm2 = _mm512_sub_epi32(r_xmm1, r_xmm0);
-        r_xmm7 = _mm512_madd_epi16(r_xmm7, _mm512_broadcast_i32x4(table26[2]));
-        r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm1);
-        r_xmm2 = _mm512_srai_epi32(r_xmm2, 12);
-        r_xmm5 = _mm512_add_epi32(r_xmm5, round_inv_row);
-        r_xmm4 = _mm512_madd_epi16(r_xmm4, _mm512_broadcast_i32x4(table26[3]));
-        r_xmm5 = _mm512_add_epi32(r_xmm5, r_xmm6);
-        r_xmm0 = _mm512_srai_epi32(r_xmm0, 12);
-        r_xmm2 = _mm512_shuffle_epi32(r_xmm2, (_MM_PERM_ENUM)(0x1b));
-        row4 = _mm512_packs_epi32(r_xmm0, r_xmm2);
-
-        r_xmm4 = _mm512_add_epi32(r_xmm4, r_xmm7);
-        r_xmm6 = _mm512_sub_epi32(r_xmm5, r_xmm4);
-        r_xmm4 = _mm512_add_epi32(r_xmm4, r_xmm5);
-        r_xmm6 = _mm512_srai_epi32(r_xmm6, 12);
-        r_xmm4 = _mm512_srai_epi32(r_xmm4, 12);
-        r_xmm6 = _mm512_shuffle_epi32(r_xmm6, (_MM_PERM_ENUM)(0x1b));
-        row6 = _mm512_packs_epi32(r_xmm4, r_xmm6);
-
-        // row 4 and row 2
-
         const __m128i* table35 = reinterpret_cast<const __m128i*>(shortM128_tab_i_35);
         const __m128i* table17 = reinterpret_cast<const __m128i*>(shortM128_tab_i_17);
-
-        r_xmm0 = _mm512_shufflelo_epi16(v3, 0xd8);
-        r_xmm1 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x00));
-        r_xmm1 = _mm512_madd_epi16(r_xmm1, _mm512_broadcast_i32x4(table35[0]));
-        r_xmm3 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x55));
-        r_xmm0 = _mm512_shufflehi_epi16(r_xmm0, 0xd8);
-        r_xmm3 = _mm512_madd_epi16(r_xmm3, _mm512_broadcast_i32x4(table35[2]));
-        r_xmm2 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xaa));
-        r_xmm0 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xff));
-        r_xmm2 = _mm512_madd_epi16(r_xmm2, _mm512_broadcast_i32x4(table35[1]));
-        r_xmm4 = _mm512_shufflehi_epi16(v1, 0xd8);
-        r_xmm1 = _mm512_add_epi32(r_xmm1, round_inv_row);
-        r_xmm4 = _mm512_shufflelo_epi16(r_xmm4, 0xd8);
-        r_xmm0 = _mm512_madd_epi16(r_xmm0, _mm512_broadcast_i32x4(table35[3]));
-        r_xmm5 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x00));
-        r_xmm6 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xaa));
-        r_xmm5 = _mm512_madd_epi16(r_xmm5, _mm512_broadcast_i32x4(table17[0]));
-        r_xmm1 = _mm512_add_epi32(r_xmm1, r_xmm2);
-        r_xmm7 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x55));
-        r_xmm6 = _mm512_madd_epi16(r_xmm6, _mm512_broadcast_i32x4(table17[1]));
-        r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm3);
-        r_xmm4 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xff));
-        r_xmm2 = _mm512_sub_epi32(r_xmm1, r_xmm0);
-        r_xmm7 = _mm512_madd_epi16(r_xmm7, _mm512_broadcast_i32x4(table17[2]));
-        r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm1);
-        r_xmm2 = _mm512_srai_epi32(r_xmm2, 12);
-        r_xmm5 = _mm512_add_epi32(r_xmm5, round_inv_row);
-        r_xmm4 = _mm512_madd_epi16(r_xmm4, _mm512_broadcast_i32x4(table17[3]));
-        r_xmm5 = _mm512_add_epi32(r_xmm5, r_xmm6);
-        r_xmm0 = _mm512_srai_epi32(r_xmm0, 12);
-        r_xmm2 = _mm512_shuffle_epi32(r_xmm2, (_MM_PERM_ENUM)(0x1b));
-        row3 = _mm512_packs_epi32(r_xmm0, r_xmm2);
-
-        r_xmm4 = _mm512_add_epi32(r_xmm4, r_xmm7);
-        r_xmm6 = _mm512_sub_epi32(r_xmm5, r_xmm4);
-        r_xmm4 = _mm512_add_epi32(r_xmm5, r_xmm4);
-        r_xmm6 = _mm512_srai_epi32(r_xmm6, 12);
-        r_xmm4 = _mm512_srai_epi32(r_xmm4, 12);
-        r_xmm6 = _mm512_shuffle_epi32(r_xmm6, (_MM_PERM_ENUM)(0x1b));
-        row1 = _mm512_packs_epi32(r_xmm4, r_xmm6);
-
-        // row 6 and row 8
-
-        r_xmm0 = _mm512_shufflelo_epi16(v5, 0xd8);
-        r_xmm1 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x00));
-        r_xmm1 = _mm512_madd_epi16(r_xmm1, _mm512_broadcast_i32x4(table35[0]));
-        r_xmm3 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x55));
-        r_xmm0 = _mm512_shufflehi_epi16(r_xmm0, 0xd8);
-        r_xmm3 = _mm512_madd_epi16(r_xmm3, _mm512_broadcast_i32x4(table35[2]));
-        r_xmm2 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xaa));
-        r_xmm0 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xff));
-        r_xmm2 = _mm512_madd_epi16(r_xmm2, _mm512_broadcast_i32x4(table35[1]));
-        r_xmm4 = _mm512_shufflehi_epi16(v7, 0xd8);
-        r_xmm1 = _mm512_add_epi32(r_xmm1, round_inv_row);
-        r_xmm4 = _mm512_shufflelo_epi16(r_xmm4, 0xd8);
-        r_xmm0 = _mm512_madd_epi16(r_xmm0, _mm512_broadcast_i32x4(table35[3]));
-        r_xmm5 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x00));
-        r_xmm6 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xaa));
-        r_xmm5 = _mm512_madd_epi16(r_xmm5, _mm512_broadcast_i32x4(table17[0]));
-        r_xmm1 = _mm512_add_epi32(r_xmm1, r_xmm2);
-        r_xmm7 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x55));
-        r_xmm6 = _mm512_madd_epi16(r_xmm6, _mm512_broadcast_i32x4(table17[1]));
-        r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm3);
-        r_xmm4 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xff));
-        r_xmm2 = _mm512_sub_epi32(r_xmm1, r_xmm0);
-        r_xmm7 = _mm512_madd_epi16(r_xmm7, _mm512_broadcast_i32x4(table17[2]));
-        r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm1);
-        r_xmm2 = _mm512_srai_epi32(r_xmm2, 12);
-        r_xmm5 = _mm512_add_epi32(r_xmm5, round_inv_row);
-        r_xmm4 = _mm512_madd_epi16(r_xmm4, _mm512_broadcast_i32x4(table17[3]));
-        r_xmm5 = _mm512_add_epi32(r_xmm5, r_xmm6);
-        r_xmm0 = _mm512_srai_epi32(r_xmm0, 12);
-        r_xmm2 = _mm512_shuffle_epi32(r_xmm2, (_MM_PERM_ENUM)(0x1b));
-        row5 = _mm512_packs_epi32(r_xmm0, r_xmm2);
-
-        r_xmm4 = _mm512_add_epi32(r_xmm4, r_xmm7);
-        r_xmm6 = _mm512_sub_epi32(r_xmm5, r_xmm4);
-        r_xmm4 = _mm512_add_epi32(r_xmm5, r_xmm4);
-        r_xmm6 = _mm512_srai_epi32(r_xmm6, 12);
-        r_xmm4 = _mm512_srai_epi32(r_xmm4, 12);
-        r_xmm6 = _mm512_shuffle_epi32(r_xmm6, (_MM_PERM_ENUM)(0x1b));
-        row7 = _mm512_packs_epi32(r_xmm4, r_xmm6);
-
+        const __m512i round_inv_row = _mm512_set1_epi32(2048);
         const __m512i tg = _mm512_broadcast_i32x4(_mm_set_epi16(-19195, -19195, -21746, -21746, 27146, 27146, 13036, 13036));
         const __m512i one = _mm512_set1_epi16(1);
-
-        r_xmm1 = _mm512_shuffle_epi32(tg, (_MM_PERM_ENUM)(0xaa));
-        r_xmm0 = _mm512_mulhi_epi16(r_xmm1, row5);
-        r_xmm1 = _mm512_mulhi_epi16(r_xmm1, row3);
-        r_xmm5 = _mm512_shuffle_epi32(tg, (_MM_PERM_ENUM)(0x00));
-        r_xmm4 = _mm512_mulhi_epi16(r_xmm5, row7);
-        r_xmm5 = _mm512_mulhi_epi16(r_xmm5, row1);
-        r_xmm0 = _mm512_adds_epi16(r_xmm0, row5);
-        r_xmm1 = _mm512_adds_epi16(r_xmm1, row3);
-        r_xmm0 = _mm512_adds_epi16(r_xmm0, row3);
-        r_xmm3 = _mm512_shuffle_epi32(tg, (_MM_PERM_ENUM)(0x55));
-        r_xmm7 = _mm512_mulhi_epi16(r_xmm3, row6);
-        r_xmm3 = _mm512_mulhi_epi16(r_xmm3, row2);
-        r_xmm5 = _mm512_subs_epi16(r_xmm5, row7);
-        r_xmm4 = _mm512_adds_epi16(r_xmm4, row1);
-        r_xmm2 = _mm512_subs_epi16(r_xmm2, r_xmm1);
-        r_xmm1 = _mm512_adds_epi16(r_xmm0, r_xmm4);
-        r_xmm1 = _mm512_adds_epi16(r_xmm1, one);
-        r_xmm4 = _mm512_subs_epi16(r_xmm4, r_xmm0);
-        r_xmm6 = _mm512_adds_epi16(r_xmm5, r_xmm2);
-        r_xmm5 = _mm512_subs_epi16(r_xmm5, r_xmm2);
-        r_xmm5 = _mm512_adds_epi16(r_xmm5, one);
-
-        __m512i temp7 = r_xmm1;
-        __m512i temp3 = r_xmm6;
-
-        r_xmm0 = _mm512_shuffle_epi32(tg, (_MM_PERM_ENUM)(0xff));
-        r_xmm1 = _mm512_subs_epi16(r_xmm4, r_xmm5);
-        r_xmm4 = _mm512_adds_epi16(r_xmm4, r_xmm5);
-        r_xmm2 = _mm512_mulhi_epi16(r_xmm0, r_xmm4);
-        r_xmm7 = _mm512_adds_epi16(r_xmm7, row2);
-        r_xmm3 = _mm512_subs_epi16(r_xmm3, row6);
-        r_xmm0 = _mm512_mulhi_epi16(r_xmm0, r_xmm1);
-        r_xmm0 = _mm512_adds_epi16(r_xmm0, r_xmm1);
-        r_xmm5 = _mm512_adds_epi16(row0, row4);
-        r_xmm6 = _mm512_subs_epi16(row0, row4);
-        r_xmm4 = _mm512_adds_epi16(r_xmm4, r_xmm2);
-
-        r_xmm4 = _mm512_or_si512(r_xmm4, one);
-        r_xmm0 = _mm512_or_si512(r_xmm0, one);
-
         const s16 bias = 128 << 5;
         const __m512i round_inv_col = _mm512_set1_epi16(16 + bias);
         const __m512i round_inv_corr = _mm512_sub_epi16(round_inv_col, one);
 
-        r_xmm1 = _mm512_subs_epi16(r_xmm6, r_xmm3);
-        r_xmm1 = _mm512_adds_epi16(r_xmm1, round_inv_corr);
-        r_xmm2 = _mm512_subs_epi16(r_xmm5, r_xmm7);
-        r_xmm2 = _mm512_adds_epi16(r_xmm2, round_inv_corr);
-        r_xmm5 = _mm512_adds_epi16(r_xmm5, r_xmm7);
-        r_xmm5 = _mm512_adds_epi16(r_xmm5, round_inv_col);
-        r_xmm6 = _mm512_adds_epi16(r_xmm6, r_xmm3);
-        r_xmm6 = _mm512_adds_epi16(r_xmm6, round_inv_col);
-
-        __m512i r0 = _mm512_adds_epi16(r_xmm5, temp7);
-        __m512i r1 = _mm512_adds_epi16(r_xmm6, r_xmm4);
-        __m512i r2 = _mm512_adds_epi16(r_xmm1, r_xmm0);
-        __m512i r3 = _mm512_adds_epi16(r_xmm2, temp3);
-        __m512i r4 = _mm512_subs_epi16(r_xmm2, temp3);
-        __m512i r5 = _mm512_subs_epi16(r_xmm1, r_xmm0);
-        __m512i r6 = _mm512_subs_epi16(r_xmm6, r_xmm4);
-        __m512i r7 = _mm512_subs_epi16(r_xmm5, temp7);
-
-        r0 = _mm512_srai_epi16(r0, 5);
-        r1 = _mm512_srai_epi16(r1, 5);
-        r2 = _mm512_srai_epi16(r2, 5);
-        r3 = _mm512_srai_epi16(r3, 5);
-        r4 = _mm512_srai_epi16(r4, 5);
-        r5 = _mm512_srai_epi16(r5, 5);
-        r6 = _mm512_srai_epi16(r6, 5);
-        r7 = _mm512_srai_epi16(r7, 5);
-
-        __m512i s0 = _mm512_packus_epi16(r0, r1);
-        __m512i s1 = _mm512_packus_epi16(r2, r3);
-        __m512i s2 = _mm512_packus_epi16(r4, r5);
-        __m512i s3 = _mm512_packus_epi16(r6, r7);
-
-
-        // store: 128-bit lanes 0..3 -> dest0..dest3
-        auto store4 = [&](__m512i s, int i)
+        auto load4 = [](const __m128i* a, const __m128i* b, const __m128i* c, const __m128i* d, int i) -> __m512i
         {
-            _mm_storeu_si128(reinterpret_cast<__m128i *>(dest0) + i, _mm512_extracti32x4_epi32(s, 0));
-            _mm_storeu_si128(reinterpret_cast<__m128i *>(dest1) + i, _mm512_extracti32x4_epi32(s, 1));
-            _mm_storeu_si128(reinterpret_cast<__m128i *>(dest2) + i, _mm512_extracti32x4_epi32(s, 2));
-            _mm_storeu_si128(reinterpret_cast<__m128i *>(dest3) + i, _mm512_extracti32x4_epi32(s, 3));
+            return _mm512_inserti32x4(
+                _mm512_inserti32x4(
+                    _mm512_inserti32x4(_mm512_castsi128_si512(a[i]), b[i], 1),
+                    c[i], 2),
+                d[i], 3);
         };
 
-        store4(s0, 0);
-        store4(s1, 1);
-        store4(s2, 2);
-        store4(s3, 3);
+        for (int n = 0; n < count; n += 4)
+        {
+            const __m128i* data0 = reinterpret_cast<const __m128i *>(src + 0);
+            const __m128i* data1 = reinterpret_cast<const __m128i *>(src + 64);
+            const __m128i* data2 = reinterpret_cast<const __m128i *>(src + 128);
+            const __m128i* data3 = reinterpret_cast<const __m128i *>(src + 192);
+            const __m128i* q0 = reinterpret_cast<const __m128i *>(qt[idx + 0]);
+            const __m128i* q1 = reinterpret_cast<const __m128i *>(qt[idx + 1]);
+            const __m128i* q2 = reinterpret_cast<const __m128i *>(qt[idx + 2]);
+            const __m128i* q3 = reinterpret_cast<const __m128i *>(qt[idx + 3]);
+
+            __m512i v0 = _mm512_mullo_epi16(load4(data0, data1, data2, data3, 0), load4(q0, q1, q2, q3, 0));
+            __m512i v1 = _mm512_mullo_epi16(load4(data0, data1, data2, data3, 1), load4(q0, q1, q2, q3, 1));
+            __m512i v2 = _mm512_mullo_epi16(load4(data0, data1, data2, data3, 2), load4(q0, q1, q2, q3, 2));
+            __m512i v3 = _mm512_mullo_epi16(load4(data0, data1, data2, data3, 3), load4(q0, q1, q2, q3, 3));
+            __m512i v4 = _mm512_mullo_epi16(load4(data0, data1, data2, data3, 4), load4(q0, q1, q2, q3, 4));
+            __m512i v5 = _mm512_mullo_epi16(load4(data0, data1, data2, data3, 5), load4(q0, q1, q2, q3, 5));
+            __m512i v6 = _mm512_mullo_epi16(load4(data0, data1, data2, data3, 6), load4(q0, q1, q2, q3, 6));
+            __m512i v7 = _mm512_mullo_epi16(load4(data0, data1, data2, data3, 7), load4(q0, q1, q2, q3, 7));
+
+            __m512i r_xmm0, r_xmm1, r_xmm2, r_xmm3, r_xmm4, r_xmm5, r_xmm6, r_xmm7;
+            __m512i row0, row1, row2, row3, row4, row5, row6, row7;
+
+            // row 1 and Row 3
+
+            r_xmm0 = _mm512_shufflelo_epi16(v0, 0xd8);
+            r_xmm1 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x00));
+            r_xmm1 = _mm512_madd_epi16(r_xmm1, _mm512_broadcast_i32x4(table04[0]));
+            r_xmm3 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x55));
+            r_xmm0 = _mm512_shufflehi_epi16(r_xmm0, 0xd8);
+            r_xmm3 = _mm512_madd_epi16(r_xmm3, _mm512_broadcast_i32x4(table04[2]));
+            r_xmm2 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xaa));
+            r_xmm0 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xff));
+            r_xmm2 = _mm512_madd_epi16(r_xmm2, _mm512_broadcast_i32x4(table04[1]));
+
+            r_xmm4 = _mm512_shufflehi_epi16(v2, 0xd8);
+            r_xmm1 = _mm512_add_epi32(r_xmm1, round_inv_row);
+            r_xmm4 = _mm512_shufflelo_epi16(r_xmm4, 0xd8);
+            r_xmm0 = _mm512_madd_epi16(r_xmm0, _mm512_broadcast_i32x4(table04[3]));
+            r_xmm5 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x00));
+            r_xmm6 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xaa));
+            r_xmm5 = _mm512_madd_epi16(r_xmm5, _mm512_broadcast_i32x4(table26[0]));
+            r_xmm1 = _mm512_add_epi32(r_xmm1, r_xmm2);
+            r_xmm7 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x55));
+            r_xmm6 = _mm512_madd_epi16(r_xmm6, _mm512_broadcast_i32x4(table26[1]));
+            r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm3);
+            r_xmm4 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xff));
+            r_xmm2 = _mm512_sub_epi32(r_xmm1, r_xmm0);
+            r_xmm7 = _mm512_madd_epi16(r_xmm7, _mm512_broadcast_i32x4(table26[2]));
+            r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm1);
+            r_xmm2 = _mm512_srai_epi32(r_xmm2, 12);
+            r_xmm5 = _mm512_add_epi32(r_xmm5, round_inv_row);
+            r_xmm4 = _mm512_madd_epi16(r_xmm4, _mm512_broadcast_i32x4(table26[3]));
+            r_xmm5 = _mm512_add_epi32(r_xmm5, r_xmm6);
+            r_xmm0 = _mm512_srai_epi32(r_xmm0, 12);
+            r_xmm2 = _mm512_shuffle_epi32(r_xmm2, (_MM_PERM_ENUM)(0x1b));
+            row0 = _mm512_packs_epi32(r_xmm0, r_xmm2);
+
+            r_xmm4 = _mm512_add_epi32(r_xmm4, r_xmm7);
+            r_xmm6 = _mm512_sub_epi32(r_xmm5, r_xmm4);
+            r_xmm4 = _mm512_add_epi32(r_xmm4, r_xmm5);
+            r_xmm6 = _mm512_srai_epi32(r_xmm6, 12);
+            r_xmm4 = _mm512_srai_epi32(r_xmm4, 12);
+            r_xmm6 = _mm512_shuffle_epi32(r_xmm6, (_MM_PERM_ENUM)(0x1b));
+            row2 = _mm512_packs_epi32(r_xmm4, r_xmm6);
+
+            // row 5 and row 7
+
+            r_xmm0 = _mm512_shufflelo_epi16(v4, 0xd8);
+            r_xmm1 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x00));
+            r_xmm1 = _mm512_madd_epi16(r_xmm1, _mm512_broadcast_i32x4(table04[0]));
+            r_xmm3 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x55));
+            r_xmm0 = _mm512_shufflehi_epi16(r_xmm0, 0xd8);
+            r_xmm3 = _mm512_madd_epi16(r_xmm3, _mm512_broadcast_i32x4(table04[2]));
+            r_xmm2 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xaa));
+            r_xmm0 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xff));
+            r_xmm2 = _mm512_madd_epi16(r_xmm2, _mm512_broadcast_i32x4(table04[1]));
+            r_xmm4 = _mm512_shufflehi_epi16(v6, 0xd8);
+            r_xmm1 = _mm512_add_epi32(r_xmm1, round_inv_row);
+            r_xmm4 = _mm512_shufflelo_epi16(r_xmm4, 0xd8);
+            r_xmm0 = _mm512_madd_epi16(r_xmm0, _mm512_broadcast_i32x4(table04[3]));
+            r_xmm5 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x00));
+            r_xmm6 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xaa));
+            r_xmm5 = _mm512_madd_epi16(r_xmm5, _mm512_broadcast_i32x4(table26[0]));
+            r_xmm1 = _mm512_add_epi32(r_xmm1, r_xmm2);
+            r_xmm7 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x55));
+            r_xmm6 = _mm512_madd_epi16(r_xmm6, _mm512_broadcast_i32x4(table26[1]));
+            r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm3);
+            r_xmm4 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xff));
+            r_xmm2 = _mm512_sub_epi32(r_xmm1, r_xmm0);
+            r_xmm7 = _mm512_madd_epi16(r_xmm7, _mm512_broadcast_i32x4(table26[2]));
+            r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm1);
+            r_xmm2 = _mm512_srai_epi32(r_xmm2, 12);
+            r_xmm5 = _mm512_add_epi32(r_xmm5, round_inv_row);
+            r_xmm4 = _mm512_madd_epi16(r_xmm4, _mm512_broadcast_i32x4(table26[3]));
+            r_xmm5 = _mm512_add_epi32(r_xmm5, r_xmm6);
+            r_xmm0 = _mm512_srai_epi32(r_xmm0, 12);
+            r_xmm2 = _mm512_shuffle_epi32(r_xmm2, (_MM_PERM_ENUM)(0x1b));
+            row4 = _mm512_packs_epi32(r_xmm0, r_xmm2);
+
+            r_xmm4 = _mm512_add_epi32(r_xmm4, r_xmm7);
+            r_xmm6 = _mm512_sub_epi32(r_xmm5, r_xmm4);
+            r_xmm4 = _mm512_add_epi32(r_xmm4, r_xmm5);
+            r_xmm6 = _mm512_srai_epi32(r_xmm6, 12);
+            r_xmm4 = _mm512_srai_epi32(r_xmm4, 12);
+            r_xmm6 = _mm512_shuffle_epi32(r_xmm6, (_MM_PERM_ENUM)(0x1b));
+            row6 = _mm512_packs_epi32(r_xmm4, r_xmm6);
+
+            // row 4 and row 2
+
+            r_xmm0 = _mm512_shufflelo_epi16(v3, 0xd8);
+            r_xmm1 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x00));
+            r_xmm1 = _mm512_madd_epi16(r_xmm1, _mm512_broadcast_i32x4(table35[0]));
+            r_xmm3 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x55));
+            r_xmm0 = _mm512_shufflehi_epi16(r_xmm0, 0xd8);
+            r_xmm3 = _mm512_madd_epi16(r_xmm3, _mm512_broadcast_i32x4(table35[2]));
+            r_xmm2 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xaa));
+            r_xmm0 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xff));
+            r_xmm2 = _mm512_madd_epi16(r_xmm2, _mm512_broadcast_i32x4(table35[1]));
+            r_xmm4 = _mm512_shufflehi_epi16(v1, 0xd8);
+            r_xmm1 = _mm512_add_epi32(r_xmm1, round_inv_row);
+            r_xmm4 = _mm512_shufflelo_epi16(r_xmm4, 0xd8);
+            r_xmm0 = _mm512_madd_epi16(r_xmm0, _mm512_broadcast_i32x4(table35[3]));
+            r_xmm5 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x00));
+            r_xmm6 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xaa));
+            r_xmm5 = _mm512_madd_epi16(r_xmm5, _mm512_broadcast_i32x4(table17[0]));
+            r_xmm1 = _mm512_add_epi32(r_xmm1, r_xmm2);
+            r_xmm7 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x55));
+            r_xmm6 = _mm512_madd_epi16(r_xmm6, _mm512_broadcast_i32x4(table17[1]));
+            r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm3);
+            r_xmm4 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xff));
+            r_xmm2 = _mm512_sub_epi32(r_xmm1, r_xmm0);
+            r_xmm7 = _mm512_madd_epi16(r_xmm7, _mm512_broadcast_i32x4(table17[2]));
+            r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm1);
+            r_xmm2 = _mm512_srai_epi32(r_xmm2, 12);
+            r_xmm5 = _mm512_add_epi32(r_xmm5, round_inv_row);
+            r_xmm4 = _mm512_madd_epi16(r_xmm4, _mm512_broadcast_i32x4(table17[3]));
+            r_xmm5 = _mm512_add_epi32(r_xmm5, r_xmm6);
+            r_xmm0 = _mm512_srai_epi32(r_xmm0, 12);
+            r_xmm2 = _mm512_shuffle_epi32(r_xmm2, (_MM_PERM_ENUM)(0x1b));
+            row3 = _mm512_packs_epi32(r_xmm0, r_xmm2);
+
+            r_xmm4 = _mm512_add_epi32(r_xmm4, r_xmm7);
+            r_xmm6 = _mm512_sub_epi32(r_xmm5, r_xmm4);
+            r_xmm4 = _mm512_add_epi32(r_xmm5, r_xmm4);
+            r_xmm6 = _mm512_srai_epi32(r_xmm6, 12);
+            r_xmm4 = _mm512_srai_epi32(r_xmm4, 12);
+            r_xmm6 = _mm512_shuffle_epi32(r_xmm6, (_MM_PERM_ENUM)(0x1b));
+            row1 = _mm512_packs_epi32(r_xmm4, r_xmm6);
+
+            // row 6 and row 8
+
+            r_xmm0 = _mm512_shufflelo_epi16(v5, 0xd8);
+            r_xmm1 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x00));
+            r_xmm1 = _mm512_madd_epi16(r_xmm1, _mm512_broadcast_i32x4(table35[0]));
+            r_xmm3 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0x55));
+            r_xmm0 = _mm512_shufflehi_epi16(r_xmm0, 0xd8);
+            r_xmm3 = _mm512_madd_epi16(r_xmm3, _mm512_broadcast_i32x4(table35[2]));
+            r_xmm2 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xaa));
+            r_xmm0 = _mm512_shuffle_epi32(r_xmm0, (_MM_PERM_ENUM)(0xff));
+            r_xmm2 = _mm512_madd_epi16(r_xmm2, _mm512_broadcast_i32x4(table35[1]));
+            r_xmm4 = _mm512_shufflehi_epi16(v7, 0xd8);
+            r_xmm1 = _mm512_add_epi32(r_xmm1, round_inv_row);
+            r_xmm4 = _mm512_shufflelo_epi16(r_xmm4, 0xd8);
+            r_xmm0 = _mm512_madd_epi16(r_xmm0, _mm512_broadcast_i32x4(table35[3]));
+            r_xmm5 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x00));
+            r_xmm6 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xaa));
+            r_xmm5 = _mm512_madd_epi16(r_xmm5, _mm512_broadcast_i32x4(table17[0]));
+            r_xmm1 = _mm512_add_epi32(r_xmm1, r_xmm2);
+            r_xmm7 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0x55));
+            r_xmm6 = _mm512_madd_epi16(r_xmm6, _mm512_broadcast_i32x4(table17[1]));
+            r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm3);
+            r_xmm4 = _mm512_shuffle_epi32(r_xmm4, (_MM_PERM_ENUM)(0xff));
+            r_xmm2 = _mm512_sub_epi32(r_xmm1, r_xmm0);
+            r_xmm7 = _mm512_madd_epi16(r_xmm7, _mm512_broadcast_i32x4(table17[2]));
+            r_xmm0 = _mm512_add_epi32(r_xmm0, r_xmm1);
+            r_xmm2 = _mm512_srai_epi32(r_xmm2, 12);
+            r_xmm5 = _mm512_add_epi32(r_xmm5, round_inv_row);
+            r_xmm4 = _mm512_madd_epi16(r_xmm4, _mm512_broadcast_i32x4(table17[3]));
+            r_xmm5 = _mm512_add_epi32(r_xmm5, r_xmm6);
+            r_xmm0 = _mm512_srai_epi32(r_xmm0, 12);
+            r_xmm2 = _mm512_shuffle_epi32(r_xmm2, (_MM_PERM_ENUM)(0x1b));
+            row5 = _mm512_packs_epi32(r_xmm0, r_xmm2);
+
+            r_xmm4 = _mm512_add_epi32(r_xmm4, r_xmm7);
+            r_xmm6 = _mm512_sub_epi32(r_xmm5, r_xmm4);
+            r_xmm4 = _mm512_add_epi32(r_xmm5, r_xmm4);
+            r_xmm6 = _mm512_srai_epi32(r_xmm6, 12);
+            r_xmm4 = _mm512_srai_epi32(r_xmm4, 12);
+            r_xmm6 = _mm512_shuffle_epi32(r_xmm6, (_MM_PERM_ENUM)(0x1b));
+            row7 = _mm512_packs_epi32(r_xmm4, r_xmm6);
+
+            r_xmm1 = _mm512_shuffle_epi32(tg, (_MM_PERM_ENUM)(0xaa));
+            r_xmm0 = _mm512_mulhi_epi16(r_xmm1, row5);
+            r_xmm1 = _mm512_mulhi_epi16(r_xmm1, row3);
+            r_xmm5 = _mm512_shuffle_epi32(tg, (_MM_PERM_ENUM)(0x00));
+            r_xmm4 = _mm512_mulhi_epi16(r_xmm5, row7);
+            r_xmm5 = _mm512_mulhi_epi16(r_xmm5, row1);
+            r_xmm0 = _mm512_adds_epi16(r_xmm0, row5);
+            r_xmm1 = _mm512_adds_epi16(r_xmm1, row3);
+            r_xmm0 = _mm512_adds_epi16(r_xmm0, row3);
+            r_xmm3 = _mm512_shuffle_epi32(tg, (_MM_PERM_ENUM)(0x55));
+            r_xmm7 = _mm512_mulhi_epi16(r_xmm3, row6);
+            r_xmm3 = _mm512_mulhi_epi16(r_xmm3, row2);
+            r_xmm5 = _mm512_subs_epi16(r_xmm5, row7);
+            r_xmm4 = _mm512_adds_epi16(r_xmm4, row1);
+            r_xmm2 = _mm512_subs_epi16(r_xmm2, r_xmm1);
+            r_xmm1 = _mm512_adds_epi16(r_xmm0, r_xmm4);
+            r_xmm1 = _mm512_adds_epi16(r_xmm1, one);
+            r_xmm4 = _mm512_subs_epi16(r_xmm4, r_xmm0);
+            r_xmm6 = _mm512_adds_epi16(r_xmm5, r_xmm2);
+            r_xmm5 = _mm512_subs_epi16(r_xmm5, r_xmm2);
+            r_xmm5 = _mm512_adds_epi16(r_xmm5, one);
+
+            __m512i temp7 = r_xmm1;
+            __m512i temp3 = r_xmm6;
+
+            r_xmm0 = _mm512_shuffle_epi32(tg, (_MM_PERM_ENUM)(0xff));
+            r_xmm1 = _mm512_subs_epi16(r_xmm4, r_xmm5);
+            r_xmm4 = _mm512_adds_epi16(r_xmm4, r_xmm5);
+            r_xmm2 = _mm512_mulhi_epi16(r_xmm0, r_xmm4);
+            r_xmm7 = _mm512_adds_epi16(r_xmm7, row2);
+            r_xmm3 = _mm512_subs_epi16(r_xmm3, row6);
+            r_xmm0 = _mm512_mulhi_epi16(r_xmm0, r_xmm1);
+            r_xmm0 = _mm512_adds_epi16(r_xmm0, r_xmm1);
+            r_xmm5 = _mm512_adds_epi16(row0, row4);
+            r_xmm6 = _mm512_subs_epi16(row0, row4);
+            r_xmm4 = _mm512_adds_epi16(r_xmm4, r_xmm2);
+
+            r_xmm4 = _mm512_or_si512(r_xmm4, one);
+            r_xmm0 = _mm512_or_si512(r_xmm0, one);
+
+            r_xmm1 = _mm512_subs_epi16(r_xmm6, r_xmm3);
+            r_xmm1 = _mm512_adds_epi16(r_xmm1, round_inv_corr);
+            r_xmm2 = _mm512_subs_epi16(r_xmm5, r_xmm7);
+            r_xmm2 = _mm512_adds_epi16(r_xmm2, round_inv_corr);
+            r_xmm5 = _mm512_adds_epi16(r_xmm5, r_xmm7);
+            r_xmm5 = _mm512_adds_epi16(r_xmm5, round_inv_col);
+            r_xmm6 = _mm512_adds_epi16(r_xmm6, r_xmm3);
+            r_xmm6 = _mm512_adds_epi16(r_xmm6, round_inv_col);
+
+            __m512i r0 = _mm512_adds_epi16(r_xmm5, temp7);
+            __m512i r1 = _mm512_adds_epi16(r_xmm6, r_xmm4);
+            __m512i r2 = _mm512_adds_epi16(r_xmm1, r_xmm0);
+            __m512i r3 = _mm512_adds_epi16(r_xmm2, temp3);
+            __m512i r4 = _mm512_subs_epi16(r_xmm2, temp3);
+            __m512i r5 = _mm512_subs_epi16(r_xmm1, r_xmm0);
+            __m512i r6 = _mm512_subs_epi16(r_xmm6, r_xmm4);
+            __m512i r7 = _mm512_subs_epi16(r_xmm5, temp7);
+
+            r0 = _mm512_srai_epi16(r0, 5);
+            r1 = _mm512_srai_epi16(r1, 5);
+            r2 = _mm512_srai_epi16(r2, 5);
+            r3 = _mm512_srai_epi16(r3, 5);
+            r4 = _mm512_srai_epi16(r4, 5);
+            r5 = _mm512_srai_epi16(r5, 5);
+            r6 = _mm512_srai_epi16(r6, 5);
+            r7 = _mm512_srai_epi16(r7, 5);
+
+            __m512i s0 = _mm512_packus_epi16(r0, r1);
+            __m512i s1 = _mm512_packus_epi16(r2, r3);
+            __m512i s2 = _mm512_packus_epi16(r4, r5);
+            __m512i s3 = _mm512_packus_epi16(r6, r7);
+
+            /*
+            auto store4 = [&](__m512i s, int i)
+            {
+                _mm_storeu_si128(reinterpret_cast<__m128i *>(dest +   0) + i, _mm512_extracti32x4_epi32(s, 0));
+                _mm_storeu_si128(reinterpret_cast<__m128i *>(dest +  64) + i, _mm512_extracti32x4_epi32(s, 1));
+                _mm_storeu_si128(reinterpret_cast<__m128i *>(dest + 128) + i, _mm512_extracti32x4_epi32(s, 2));
+                _mm_storeu_si128(reinterpret_cast<__m128i *>(dest + 192) + i, _mm512_extracti32x4_epi32(s, 3));
+            };
+
+            store4(s0, 0);
+            store4(s1, 1);
+            store4(s2, 2);
+            store4(s3, 3);
+
+            __m512i s0 = _mm512_packus_epi16(r0, r1);
+            __m512i s1 = _mm512_packus_epi16(r2, r3);
+            __m512i s2 = _mm512_packus_epi16(r4, r5);
+            __m512i s3 = _mm512_packus_epi16(r6, r7);
+            */
+
+            /*
+            auto pack4 = [] (__m512i a, __m512i b, __m512i c, __m512i d, int lane)
+            {
+                __m128i x0 = _mm512_extracti32x4_epi32(a, lane);
+                __m128i x1 = _mm512_extracti32x4_epi32(b, lane);
+                __m128i x2 = _mm512_extracti32x4_epi32(c, lane);
+                __m128i x3 = _mm512_extracti32x4_epi32(d, lane);
+                __m512i r = _mm512_castsi128_si512(x0);
+                r = _mm512_inserti32x4(r, x1, 1);
+                r = _mm512_inserti32x4(r, x2, 2);
+                r = _mm512_inserti32x4(r, x3, 3);
+                return r;
+            };
+
+            __m512i* d = reinterpret_cast<__m512i*>(dest);
+            d[0] = pack4(s0, s1, s2, s3, 0);
+            d[1] = pack4(s0, s1, s2, s3, 1);
+            d[2] = pack4(s0, s1, s2, s3, 2);
+            d[3] = pack4(s0, s1, s2, s3, 3);
+            */
+
+            // s0 = A0 A1 A2 A3, s1 = B0 B1 B2 B3, ...
+            __m512i t0 = _mm512_shuffle_i32x4(s0, s1, 0x44); // A0 A1 B0 B1
+            __m512i t1 = _mm512_shuffle_i32x4(s0, s1, 0xEE); // A2 A3 B2 B3
+            __m512i t2 = _mm512_shuffle_i32x4(s2, s3, 0x44); // C0 C1 D0 D1
+            __m512i t3 = _mm512_shuffle_i32x4(s2, s3, 0xEE); // C2 C3 D2 D3
+
+            __m512i d0 = _mm512_shuffle_i32x4(t0, t2, 0x88); // A0 B0 C0 D0
+            __m512i d1 = _mm512_shuffle_i32x4(t0, t2, 0xDD); // A1 B1 C1 D1
+            __m512i d2 = _mm512_shuffle_i32x4(t1, t3, 0x88); // A2 B2 C2 D2
+            __m512i d3 = _mm512_shuffle_i32x4(t1, t3, 0xDD); // A3 B3 C3 D3
+
+            _mm512_storeu_si512(dest +   0, d0);
+            _mm512_storeu_si512(dest +  64, d1);
+            _mm512_storeu_si512(dest + 128, d2);
+            _mm512_storeu_si512(dest + 192, d3);
+
+            dest += 256;
+            src += 256;
+            idx += 4;
+
+            while (idx >= blocks)
+            {
+                idx -= blocks;
+            }
+        }
     }
 
 

--- a/source/mango/jpeg/jpeg_idct.cpp
+++ b/source/mango/jpeg/jpeg_idct.cpp
@@ -165,7 +165,7 @@ namespace mango::image::jpeg
     //
 
     // Table for rows 0,4 - constants are multiplied on cos_4_16
-    alignas(16) static
+    alignas(64) static
     s16 shortM128_tab_i_04 [] =
     {
         16384, 21407, 16384, 8867, 16384, -8867, 16384, -21407,
@@ -175,7 +175,7 @@ namespace mango::image::jpeg
     };
 
     // Table for rows 1,7 - constants are multiplied on cos_1_16
-    alignas(16) static
+    alignas(64) static
     s16 shortM128_tab_i_17 [] =
     {
         22725, 29692, 22725, 12299, 22725, -12299, 22725, -29692,
@@ -185,7 +185,7 @@ namespace mango::image::jpeg
     };
 
     // Table for rows 2,6 - constants are multiplied on cos_2_16
-    alignas(16) static
+    alignas(64) static
     s16 shortM128_tab_i_26 [] =
     {
         21407, 27969, 21407, 11585, 21407, -11585, 21407, -27969,
@@ -195,7 +195,7 @@ namespace mango::image::jpeg
     };
 
     // Table for rows 3,5 - constants are multiplied on cos_3_16
-    alignas(16) static
+    alignas(64) static
     s16 shortM128_tab_i_35 [] =
     {
         19266, 25172, 19266, 10426, 19266, -10426, 19266, -25172,
@@ -813,16 +813,17 @@ namespace mango::image::jpeg
     // Linear quad 8x8 iDCT: consecutive blocks in 128-bit lanes, fused dequant.
     void idct_avx512(u8* dest, const s16* src, const s16* const* qt, int blocks, int idx, int count)
     {
-        const __m128i* table04 = reinterpret_cast<const __m128i*>(shortM128_tab_i_04);
-        const __m128i* table26 = reinterpret_cast<const __m128i*>(shortM128_tab_i_26);
-        const __m128i* table35 = reinterpret_cast<const __m128i*>(shortM128_tab_i_35);
-        const __m128i* table17 = reinterpret_cast<const __m128i*>(shortM128_tab_i_17);
         const __m512i round_inv_row = _mm512_set1_epi32(2048);
         const __m512i tg = _mm512_broadcast_i32x4(_mm_set_epi16(-19195, -19195, -21746, -21746, 27146, 27146, 13036, 13036));
         const __m512i one = _mm512_set1_epi16(1);
         const s16 bias = 128 << 5;
         const __m512i round_inv_col = _mm512_set1_epi16(16 + bias);
         const __m512i round_inv_corr = _mm512_sub_epi16(round_inv_col, one);
+
+        const __m128i* table04 = reinterpret_cast<const __m128i*>(shortM128_tab_i_04);
+        const __m128i* table26 = reinterpret_cast<const __m128i*>(shortM128_tab_i_26);
+        const __m128i* table35 = reinterpret_cast<const __m128i*>(shortM128_tab_i_35);
+        const __m128i* table17 = reinterpret_cast<const __m128i*>(shortM128_tab_i_17);
 
         for (int n = 0; n < count; n += 4)
         {
@@ -1139,7 +1140,7 @@ namespace mango::image::jpeg
     // ------------------------------------------------------------------------------------------------
 
     // Table for rows 0,4 - constants are multiplied on cos_4_16
-    alignas(16) static
+    alignas(64) static
     s16 shortM128_tab_i_04 [] =
     {
         16384, 21407, 16384, 8867, 16384, -8867, 16384, -21407,
@@ -1149,7 +1150,7 @@ namespace mango::image::jpeg
     };
 
     // Table for rows 1,7 - constants are multiplied on cos_1_16
-    alignas(16) static
+    alignas(64) static
     s16 shortM128_tab_i_17 [] =
     {
         22725, 29692, 22725, 12299, 22725, -12299, 22725, -29692,
@@ -1159,7 +1160,7 @@ namespace mango::image::jpeg
     };
 
     // Table for rows 2,6 - constants are multiplied on cos_2_16
-    alignas(16) static
+    alignas(64) static
     s16 shortM128_tab_i_26 [] =
     {
         21407, 27969, 21407, 11585, 21407, -11585, 21407, -27969,
@@ -1169,7 +1170,7 @@ namespace mango::image::jpeg
     };
 
     // Table for rows 3,5 - constants are multiplied on cos_3_16
-    alignas(16) static
+    alignas(64) static
     s16 shortM128_tab_i_35 [] =
     {
         19266, 25172, 19266, 10426, 19266, -10426, 19266, -25172,

--- a/source/mango/jpeg/jpeg_process.cpp
+++ b/source/mango/jpeg/jpeg_process.cpp
@@ -46,7 +46,7 @@ void process_y_8bit(u8* dest, size_t stride, const u8* spatial, ProcessState* st
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int y = 0; y < height; ++y)
         {
@@ -65,7 +65,7 @@ void process_y_24bit(u8* dest, size_t stride, const u8* spatial, ProcessState* s
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int y = 0; y < height; ++y)
         {
@@ -95,7 +95,7 @@ void process_y_32bit(u8* dest, size_t stride, const u8* spatial, ProcessState* s
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int y = 0; y < height; ++y)
         {
@@ -122,7 +122,7 @@ void process_cmyk_rgba(u8* dest, size_t stride, const u8* spatial, ProcessState*
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         // MCU dimension in blocks
     int hmax = std::max(std::max(state->frame[0].hsf, state->frame[1].hsf), state->frame[2].hsf);
@@ -250,7 +250,7 @@ void process_cmyk_store_rgba(u8* dest, size_t stride, const u8* spatial, Process
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         int hmax = std::max(std::max(state->frame[0].hsf, state->frame[1].hsf), state->frame[2].hsf);
     int vmax = std::max(std::max(state->frame[0].vsf, state->frame[1].vsf), state->frame[2].vsf);
@@ -458,7 +458,7 @@ void process_ycbcr_8bit(u8* dest, size_t stride, const u8* spatial, ProcessState
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         // MCU size in blocks
         int xsize = (width + 7) / 8;
@@ -498,7 +498,7 @@ void process_rgb_bgr(u8* dest, size_t stride, const u8* spatial, ProcessState* s
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int y = 0; y < 8; ++y)
         {
@@ -529,7 +529,7 @@ void process_rgb_rgb(u8* dest, size_t stride, const u8* spatial, ProcessState* s
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int y = 0; y < 8; ++y)
         {
@@ -560,7 +560,7 @@ void process_rgb_bgra(u8* dest, size_t stride, const u8* spatial, ProcessState* 
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int y = 0; y < 8; ++y)
         {
@@ -592,7 +592,7 @@ void process_rgb_rgba(u8* dest, size_t stride, const u8* spatial, ProcessState* 
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int y = 0; y < 8; ++y)
         {
@@ -1259,7 +1259,7 @@ void process_ycbcr_rgba_8x8_avx2_color(u8* dest, size_t stride, const u8* spatia
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int y = 0; y < 2; ++y)
         {

--- a/source/mango/jpeg/jpeg_process.cpp
+++ b/source/mango/jpeg/jpeg_process.cpp
@@ -115,6 +115,19 @@ void process_y_32bit(u8* dest, size_t stride, const u8* spatial, ProcessState* s
     MANGO_UNREFERENCED(state);
 }
 
+static
+void get_cmyk_mcu_extent(const ProcessState* state, int& hmax, int& vmax)
+{
+    hmax = 1;
+    vmax = 1;
+
+    for (int i = 0; i < state->frames; ++i)
+    {
+        hmax = std::max(hmax, state->frame[i].hsf);
+        vmax = std::max(vmax, state->frame[i].vsf);
+    }
+}
+
 void process_cmyk_rgba(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
 {
     u8* origin = dest;
@@ -125,8 +138,9 @@ void process_cmyk_rgba(u8* dest, size_t stride, const u8* spatial, ProcessState*
         const u8* result = spatial + m * state->spatialMCUBytes();
 
         // MCU dimension in blocks
-    int hmax = std::max(std::max(state->frame[0].hsf, state->frame[1].hsf), state->frame[2].hsf);
-    int vmax = std::max(std::max(state->frame[0].vsf, state->frame[1].vsf), state->frame[2].vsf);
+        int hmax;
+        int vmax;
+        get_cmyk_mcu_extent(state, hmax, vmax);
 
     u8 temp[JPEG_MAX_SAMPLES_IN_MCU * 4];
 
@@ -252,8 +266,9 @@ void process_cmyk_store_rgba(u8* dest, size_t stride, const u8* spatial, Process
         dest = origin + m * xstride;
         const u8* result = spatial + m * state->spatialMCUBytes();
 
-        int hmax = std::max(std::max(state->frame[0].hsf, state->frame[1].hsf), state->frame[2].hsf);
-    int vmax = std::max(std::max(state->frame[0].vsf, state->frame[1].vsf), state->frame[2].vsf);
+        int hmax;
+        int vmax;
+        get_cmyk_mcu_extent(state, hmax, vmax);
 
     u8 temp[JPEG_MAX_SAMPLES_IN_MCU * 4];
 
@@ -356,7 +371,7 @@ void process_cmyk_store_rgba(u8* dest, size_t stride, const u8* spatial, Process
     }
 }
 
-bool transform_cmyk_surface_to_srgb(Surface& surface, ConstMemory icc)
+bool transform_cmyk_surface_to_srgb(Surface& surface, ConstMemory icc, bool invert_adobe)
 {
     const Format rgba_u8(32, Format::UNORM, Format::RGBA, 8, 8, 8, 8);
 
@@ -399,6 +414,22 @@ bool transform_cmyk_surface_to_srgb(Surface& surface, ConstMemory icc)
     for (int y = 0; y < surface.height; ++y)
     {
         u8* row = surface.image + y * surface.stride;
+
+        // Adobe CMYK JPEG stores inverted components (0 = 100% ink). LittleCMS
+        // expects standard polarity (0 = no ink). YCCK is converted to CMYK first
+        // and does not use Adobe's inverted encoding.
+        if (invert_adobe)
+        {
+            for (int x = 0; x < surface.width; ++x)
+            {
+                u8* p = row + x * 4;
+                p[0] = 255 - p[0];
+                p[1] = 255 - p[1];
+                p[2] = 255 - p[2];
+                p[3] = 255 - p[3];
+            }
+        }
+
         cmsDoTransform(transform, row, row, width);
     }
 

--- a/source/mango/jpeg/jpeg_process.cpp
+++ b/source/mango/jpeg/jpeg_process.cpp
@@ -1216,6 +1216,54 @@ u8* convert_ycbcr_rgba_8x2_avx2(u8* dest, size_t stride, __m256i y, __m256i cb, 
     return dest;
 }
 
+void process_ycbcr_rgba_8x8_avx2_color(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
+{
+    const __m256i s0 = JPEG_CONST_AVX2(JPEG_FIXED( 1.00000), JPEG_FIXED( 1.40200));
+    const __m256i s1 = JPEG_CONST_AVX2(JPEG_FIXED( 1.00000), JPEG_FIXED( 1.77200));
+    const __m256i s2 = JPEG_CONST_AVX2(JPEG_FIXED(-0.34414), JPEG_FIXED(-0.71414));
+    const __m256i rounding = _mm256_set1_epi32(1 << (JPEG_PREC - 1));
+    const __m256i tosigned = _mm256_set1_epi16(128);
+    const __m256i alpha = _mm256_set1_epi16(0x00ff);
+
+    u8* origin = dest;
+
+    for (int m = 0; m < count; ++m)
+    {
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+
+        for (int y = 0; y < 2; ++y)
+        {
+            __m256i y0 = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(result + y * 32 + 0));
+            __m256i cb = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(result + y * 32 + 64));
+            __m256i cr = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(result + y * 32 + 128));
+
+            y0 = _mm256_permute4x64_epi64(y0, _MM_SHUFFLE(3, 1, 2, 0));
+            cb = _mm256_permute4x64_epi64(cb, _MM_SHUFFLE(3, 1, 2, 0));
+            cr = _mm256_permute4x64_epi64(cr, _MM_SHUFFLE(3, 1, 2, 0));
+
+            __m256i zero = _mm256_setzero_si256();
+
+            __m256i cb0 = _mm256_unpacklo_epi8(cb, zero);
+            __m256i cr0 = _mm256_unpacklo_epi8(cr, zero);
+            __m256i cb1 = _mm256_unpackhi_epi8(cb, zero);
+            __m256i cr1 = _mm256_unpackhi_epi8(cr, zero);
+
+            cb0 = _mm256_sub_epi16(cb0, tosigned);
+            cr0 = _mm256_sub_epi16(cr0, tosigned);
+            cb1 = _mm256_sub_epi16(cb1, tosigned);
+            cr1 = _mm256_sub_epi16(cr1, tosigned);
+
+            dest = convert_ycbcr_rgba_8x2_avx2(dest, stride, _mm256_unpacklo_epi8(y0, zero), cb0, cr0, alpha, s0, s1, s2, rounding);
+            dest = convert_ycbcr_rgba_8x2_avx2(dest, stride, _mm256_unpackhi_epi8(y0, zero), cb1, cr1, alpha, s0, s1, s2, rounding);
+        }
+    }
+
+    MANGO_UNREFERENCED(state);
+    MANGO_UNREFERENCED(width);
+    MANGO_UNREFERENCED(height);
+}
+
 void process_ycbcr_rgba_8x8_avx2(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
 {
     u8 result[64 * 3];
@@ -1224,42 +1272,7 @@ void process_ycbcr_rgba_8x8_avx2(u8* dest, size_t stride, const s16* data, Proce
     state->idct(result +  64, data +  64, state->block[1].qt); // Cb
     state->idct(result + 128, data + 128, state->block[2].qt); // Cr
 
-    // color conversion
-    const __m256i s0 = JPEG_CONST_AVX2(JPEG_FIXED( 1.00000), JPEG_FIXED( 1.40200));
-    const __m256i s1 = JPEG_CONST_AVX2(JPEG_FIXED( 1.00000), JPEG_FIXED( 1.77200));
-    const __m256i s2 = JPEG_CONST_AVX2(JPEG_FIXED(-0.34414), JPEG_FIXED(-0.71414));
-    const __m256i rounding = _mm256_set1_epi32(1 << (JPEG_PREC - 1));
-    const __m256i tosigned = _mm256_set1_epi16(128);
-    const __m256i alpha = _mm256_set1_epi16(0x00ff);
-
-    for (int y = 0; y < 2; ++y)
-    {
-        __m256i y0 = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(result + y * 32 + 0));
-        __m256i cb = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(result + y * 32 + 64));
-        __m256i cr = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(result + y * 32 + 128));
-
-        y0 = _mm256_permute4x64_epi64(y0, _MM_SHUFFLE(3, 1, 2, 0));
-        cb = _mm256_permute4x64_epi64(cb, _MM_SHUFFLE(3, 1, 2, 0));
-        cr = _mm256_permute4x64_epi64(cr, _MM_SHUFFLE(3, 1, 2, 0));
-
-        __m256i zero = _mm256_setzero_si256();
-
-        __m256i cb0 = _mm256_unpacklo_epi8(cb, zero);
-        __m256i cr0 = _mm256_unpacklo_epi8(cr, zero);
-        __m256i cb1 = _mm256_unpackhi_epi8(cb, zero);
-        __m256i cr1 = _mm256_unpackhi_epi8(cr, zero);
-
-        cb0 = _mm256_sub_epi16(cb0, tosigned);
-        cr0 = _mm256_sub_epi16(cr0, tosigned);
-        cb1 = _mm256_sub_epi16(cb1, tosigned);
-        cr1 = _mm256_sub_epi16(cr1, tosigned);
-
-        dest = convert_ycbcr_rgba_8x2_avx2(dest, stride, _mm256_unpacklo_epi8(y0, zero), cb0, cr0, alpha, s0, s1, s2, rounding);
-        dest = convert_ycbcr_rgba_8x2_avx2(dest, stride, _mm256_unpackhi_epi8(y0, zero), cb1, cr1, alpha, s0, s1, s2, rounding);
-    }
-
-    MANGO_UNREFERENCED(width);
-    MANGO_UNREFERENCED(height);
+    process_ycbcr_rgba_8x8_avx2_color(dest, stride, result, state, width, height, 1, 0);
 }
 
 #endif // MANGO_ENABLE_AVX2

--- a/source/mango/jpeg/jpeg_process.cpp
+++ b/source/mango/jpeg/jpeg_process.cpp
@@ -39,70 +39,92 @@ namespace mango::image::jpeg
 // Generic C++ implementation
 // ----------------------------------------------------------------------------
 
-void process_y_8bit(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
+void process_y_8bit(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
 {
-    u8 result[64];
-    state->idct(result, data, state->block[0].qt); // Y
+    u8* origin = dest;
 
-    for (int y = 0; y < height; ++y)
+    for (int m = 0; m < count; ++m)
     {
-        std::memcpy(dest, result + y * 8, width);
-        dest += stride;
-    }
-}
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
 
-void process_y_24bit(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
-{
-    u8 result[64];
-    state->idct(result, data, state->block[0].qt); // Y
-
-    stride -= width * 3;
-
-    for (int y = 0; y < height; ++y)
-    {
-        const u8* s = result + y * 8;
-        for (int x = 0; x < width; ++x)
+        for (int y = 0; y < height; ++y)
         {
-            u8 v = s[x];
-            dest[0] = v;
-            dest[1] = v;
-            dest[2] = v;
-            dest += 3;
+            std::memcpy(dest, result + y * 8, width);
+            dest += stride;
         }
-        dest += stride;
     }
+
+    MANGO_UNREFERENCED(state);
 }
 
-void process_y_32bit(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
+void process_y_24bit(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
 {
-    u8 result[64];
-    state->idct(result, data, state->block[0].qt); // Y
+    u8* origin = dest;
 
-    for (int y = 0; y < height; ++y)
+    for (int m = 0; m < count; ++m)
     {
-        const u8* s = result + y * 8;
-        u32* d = reinterpret_cast<u32*>(dest);
-        for (int x = 0; x < width; ++x)
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+
+        for (int y = 0; y < height; ++y)
         {
-            u32 v = s[x];
-            d[x] = 0xff000000 | (v << 16) | (v << 8) | v;
+            const u8* s = result + y * 8;
+            u8* d = dest;
+
+            for (int x = 0; x < width; ++x)
+            {
+                u8 v = s[x];
+                d[0] = v;
+                d[1] = v;
+                d[2] = v;
+                d += 3;
+            }
+
+            dest += stride;
         }
-        dest += stride;
     }
+
+    MANGO_UNREFERENCED(state);
 }
 
-void process_cmyk_rgba(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
+void process_y_32bit(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
 {
-    u8 result[JPEG_MAX_SAMPLES_IN_MCU];
+    u8* origin = dest;
 
-    for (int i = 0; i < state->blocks; ++i)
+    for (int m = 0; m < count; ++m)
     {
-        Block& block = state->block[i];
-        state->idct(result + i * 64, data, block.qt);
-        data += 64;
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+
+        for (int y = 0; y < height; ++y)
+        {
+            const u8* s = result + y * 8;
+            u32* d = reinterpret_cast<u32*>(dest);
+
+            for (int x = 0; x < width; ++x)
+            {
+                u32 v = s[x];
+                d[x] = 0xff000000 | (v << 16) | (v << 8) | v;
+            }
+
+            dest += stride;
+        }
     }
 
-    // MCU dimension in blocks
+    MANGO_UNREFERENCED(state);
+}
+
+void process_cmyk_rgba(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
+{
+    u8* origin = dest;
+
+    for (int m = 0; m < count; ++m)
+    {
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+
+        // MCU dimension in blocks
     int hmax = std::max(std::max(state->frame[0].hsf, state->frame[1].hsf), state->frame[2].hsf);
     int vmax = std::max(std::max(state->frame[0].vsf, state->frame[1].vsf), state->frame[2].vsf);
 
@@ -119,7 +141,7 @@ void process_cmyk_rgba(u8* dest, size_t stride, const s16* data, ProcessState* s
         {
             for (int xblock = 0; xblock < hsf; ++xblock)
             {
-                u8* source = result + offset + (yblock * hsf + xblock) * 64;
+                const u8* source = result + offset + (yblock * hsf + xblock) * 64;
                 u8* d = temp + channel * JPEG_MAX_SAMPLES_IN_MCU + yblock * 8 * (hmax * 8) + xblock * 8;
 
                 if (hmax != hsf || vmax != vsf)
@@ -218,20 +240,19 @@ void process_cmyk_rgba(u8* dest, size_t stride, const s16* data, ProcessState* s
             d[x] = image::makeRGBA(r, g, b, 0xff);
         }
     }
+    }
 }
 
-void process_cmyk_store_rgba(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
+void process_cmyk_store_rgba(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
 {
-    u8 result[JPEG_MAX_SAMPLES_IN_MCU];
+    u8* origin = dest;
 
-    for (int i = 0; i < state->blocks; ++i)
+    for (int m = 0; m < count; ++m)
     {
-        Block& block = state->block[i];
-        state->idct(result + i * 64, data, block.qt);
-        data += 64;
-    }
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
 
-    int hmax = std::max(std::max(state->frame[0].hsf, state->frame[1].hsf), state->frame[2].hsf);
+        int hmax = std::max(std::max(state->frame[0].hsf, state->frame[1].hsf), state->frame[2].hsf);
     int vmax = std::max(std::max(state->frame[0].vsf, state->frame[1].vsf), state->frame[2].vsf);
 
     u8 temp[JPEG_MAX_SAMPLES_IN_MCU * 4];
@@ -246,7 +267,7 @@ void process_cmyk_store_rgba(u8* dest, size_t stride, const s16* data, ProcessSt
         {
             for (int xblock = 0; xblock < hsf; ++xblock)
             {
-                u8* source = result + offset + (yblock * hsf + xblock) * 64;
+                const u8* source = result + offset + (yblock * hsf + xblock) * 64;
                 u8* d = temp + channel * JPEG_MAX_SAMPLES_IN_MCU + yblock * 8 * (hmax * 8) + xblock * 8;
 
                 if (hmax != hsf || vmax != vsf)
@@ -331,6 +352,7 @@ void process_cmyk_store_rgba(u8* dest, size_t stride, const s16* data, ProcessSt
 
             d[x] = image::makeRGBA(u8(C), u8(M), u8(Y), u8(K));
         }
+    }
     }
 }
 
@@ -429,163 +451,170 @@ void simple_cmyk_surface_to_rgba(Surface& surface)
     }
 }
 
-void process_ycbcr_8bit(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
+void process_ycbcr_8bit(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
 {
-    u8 result[JPEG_MAX_SAMPLES_IN_MCU];
+    u8* origin = dest;
 
-    const int luma_blocks = state->blocks - 2; // don't idct two last blocks (Cb, Cr)
-    for (int i = 0; i < luma_blocks; ++i)
+    for (int m = 0; m < count; ++m)
     {
-        Block& block = state->block[i];
-        state->idct(result + i * 64, data, block.qt);
-        data += 64;
-    }
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
 
-    // MCU size in blocks
-    int xsize = (width + 7) / 8;
-    int ysize = (height + 7) / 8;
+        // MCU size in blocks
+        int xsize = (width + 7) / 8;
+        int ysize = (height + 7) / 8;
 
-    // process MCU
-    for (int yb = 0; yb < ysize; ++yb)
-    {
-        // vertical clipping limit for current block
-        const int ymax = std::min(8, height - yb * 8);
-
-        for (int xb = 0; xb < xsize; ++xb)
+        for (int yb = 0; yb < ysize; ++yb)
         {
-            u8* dest_block = dest + yb * 8 * stride + xb * 8 * sizeof(u8);
-            u8* y_block = result + (yb * xsize + xb) * 64;
+            const int ymax = std::min(8, height - yb * 8);
 
-            // horizontal clipping limit for current block
-            const int xmax = std::min(8, width - xb * 8);
-
-            // process 8x8 block
-            for (int y = 0; y < ymax; ++y)
+            for (int xb = 0; xb < xsize; ++xb)
             {
-                std::memcpy(dest_block, y_block, xmax);
-                dest_block += stride;
-                y_block += 8;
+                u8* dest_block = dest + yb * 8 * stride + xb * 8 * sizeof(u8);
+                const u8* y_block = result + (yb * xsize + xb) * 64;
+                const int xmax = std::min(8, width - xb * 8);
+
+                for (int y = 0; y < ymax; ++y)
+                {
+                    std::memcpy(dest_block, y_block, xmax);
+                    dest_block += stride;
+                    y_block += 8;
+                }
             }
         }
     }
+
+    MANGO_UNREFERENCED(state);
 }
 
 // ------------------------------------------------------------------------------------------------
 // RGB
 // ------------------------------------------------------------------------------------------------
 
-void process_rgb_bgr(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
+void process_rgb_bgr(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
 {
-    u8 result[JPEG_MAX_SAMPLES_IN_MCU];
+    u8* origin = dest;
 
-    for (int i = 0; i < state->blocks; ++i)
+    for (int m = 0; m < count; ++m)
     {
-        Block& block = state->block[i];
-        state->idct(result + i * 64, data, block.qt);
-        data += 64;
-    }
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
 
-    for (int y = 0; y < 8; ++y)
-    {
-        u8* d = dest + y * stride;
-        const u8* s = result + y * 8;
-
-        for (int x = 0; x < 8; ++x)
+        for (int y = 0; y < 8; ++y)
         {
-            u8 r = s[x];
-            u8 g = s[x + 64];
-            u8 b = s[x + 128];
-            d[x * 3 + 0] = b;
-            d[x * 3 + 1] = g;
-            d[x * 3 + 2] = r;
+            u8* d = dest + y * stride;
+            const u8* s = result + y * 8;
+
+            for (int x = 0; x < 8; ++x)
+            {
+                u8 r = s[x];
+                u8 g = s[x + 64];
+                u8 b = s[x + 128];
+                d[x * 3 + 0] = b;
+                d[x * 3 + 1] = g;
+                d[x * 3 + 2] = r;
+            }
         }
     }
+
+    MANGO_UNREFERENCED(state);
+    MANGO_UNREFERENCED(width);
+    MANGO_UNREFERENCED(height);
 }
 
-void process_rgb_rgb(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
+void process_rgb_rgb(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
 {
-    u8 result[JPEG_MAX_SAMPLES_IN_MCU];
+    u8* origin = dest;
 
-    for (int i = 0; i < state->blocks; ++i)
+    for (int m = 0; m < count; ++m)
     {
-        Block& block = state->block[i];
-        state->idct(result + i * 64, data, block.qt);
-        data += 64;
-    }
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
 
-    for (int y = 0; y < 8; ++y)
-    {
-        u8* d = dest + y * stride;
-        const u8* s = result + y * 8;
-
-        for (int x = 0; x < 8; ++x)
+        for (int y = 0; y < 8; ++y)
         {
-            u8 r = s[x];
-            u8 g = s[x + 64];
-            u8 b = s[x + 128];
-            d[x * 3 + 0] = r;
-            d[x * 3 + 1] = g;
-            d[x * 3 + 2] = b;
+            u8* d = dest + y * stride;
+            const u8* s = result + y * 8;
+
+            for (int x = 0; x < 8; ++x)
+            {
+                u8 r = s[x];
+                u8 g = s[x + 64];
+                u8 b = s[x + 128];
+                d[x * 3 + 0] = r;
+                d[x * 3 + 1] = g;
+                d[x * 3 + 2] = b;
+            }
         }
     }
+
+    MANGO_UNREFERENCED(state);
+    MANGO_UNREFERENCED(width);
+    MANGO_UNREFERENCED(height);
 }
 
-void process_rgb_bgra(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
+void process_rgb_bgra(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
 {
-    u8 result[JPEG_MAX_SAMPLES_IN_MCU];
+    u8* origin = dest;
 
-    for (int i = 0; i < state->blocks; ++i)
+    for (int m = 0; m < count; ++m)
     {
-        Block& block = state->block[i];
-        state->idct(result + i * 64, data, block.qt);
-        data += 64;
-    }
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
 
-    for (int y = 0; y < 8; ++y)
-    {
-        u8* d = dest + y * stride;
-        const u8* s = result + y * 8;
-
-        for (int x = 0; x < 8; ++x)
+        for (int y = 0; y < 8; ++y)
         {
-            u8 r = s[x];
-            u8 g = s[x + 64];
-            u8 b = s[x + 128];
-            d[x * 4 + 0] = b;
-            d[x * 4 + 1] = g;
-            d[x * 4 + 2] = r;
-            d[x * 4 + 3] = 0xff;
+            u8* d = dest + y * stride;
+            const u8* s = result + y * 8;
+
+            for (int x = 0; x < 8; ++x)
+            {
+                u8 r = s[x];
+                u8 g = s[x + 64];
+                u8 b = s[x + 128];
+                d[x * 4 + 0] = b;
+                d[x * 4 + 1] = g;
+                d[x * 4 + 2] = r;
+                d[x * 4 + 3] = 0xff;
+            }
         }
     }
+
+    MANGO_UNREFERENCED(state);
+    MANGO_UNREFERENCED(width);
+    MANGO_UNREFERENCED(height);
 }
 
-void process_rgb_rgba(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
+void process_rgb_rgba(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
 {
-    u8 result[JPEG_MAX_SAMPLES_IN_MCU];
+    u8* origin = dest;
 
-    for (int i = 0; i < state->blocks; ++i)
+    for (int m = 0; m < count; ++m)
     {
-        Block& block = state->block[i];
-        state->idct(result + i * 64, data, block.qt);
-        data += 64;
-    }
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
 
-    for (int y = 0; y < 8; ++y)
-    {
-        u8* d = dest + y * stride;
-        const u8* s = result + y * 8;
-
-        for (int x = 0; x < 8; ++x)
+        for (int y = 0; y < 8; ++y)
         {
-            u8 r = s[x];
-            u8 g = s[x + 64];
-            u8 b = s[x + 128];
-            d[x * 4 + 0] = r;
-            d[x * 4 + 1] = g;
-            d[x * 4 + 2] = b;
-            d[x * 4 + 3] = 0xff;
+            u8* d = dest + y * stride;
+            const u8* s = result + y * 8;
+
+            for (int x = 0; x < 8; ++x)
+            {
+                u8 r = s[x];
+                u8 g = s[x + 64];
+                u8 b = s[x + 128];
+                d[x * 4 + 0] = r;
+                d[x * 4 + 1] = g;
+                d[x * 4 + 2] = b;
+                d[x * 4 + 3] = 0xff;
+            }
         }
     }
+
+    MANGO_UNREFERENCED(state);
+    MANGO_UNREFERENCED(width);
+    MANGO_UNREFERENCED(height);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -1262,17 +1291,6 @@ void process_ycbcr_rgba_8x8_avx2_color(u8* dest, size_t stride, const u8* spatia
     MANGO_UNREFERENCED(state);
     MANGO_UNREFERENCED(width);
     MANGO_UNREFERENCED(height);
-}
-
-void process_ycbcr_rgba_8x8_avx2(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
-{
-    u8 result[64 * 3];
-
-    state->idct(result +   0, data +   0, state->block[0].qt); // Y
-    state->idct(result +  64, data +  64, state->block[1].qt); // Cb
-    state->idct(result + 128, data + 128, state->block[2].qt); // Cr
-
-    process_ycbcr_rgba_8x8_avx2_color(dest, stride, result, state, width, height, 1, 0);
 }
 
 #endif // MANGO_ENABLE_AVX2

--- a/source/mango/jpeg/jpeg_process_func.hpp
+++ b/source/mango/jpeg/jpeg_process_func.hpp
@@ -96,6 +96,40 @@ void FUNCTION_GENERIC(u8* dest, size_t stride, const s16* data, ProcessState* st
 
 #ifdef FUNCTION_YCBCR_8x8
 
+void JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x8)(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
+{
+    u8* origin = dest;
+
+    for (int m = 0; m < count; ++m)
+    {
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+
+        for (int y = 0; y < 8; ++y)
+        {
+            const u8* s = result + y * 8;
+            u8* d = dest;
+
+            for (int x = 0; x < 8; ++x)
+            {
+                int y0 = s[x];
+                int cb = s[x + 64];
+                int cr = s[x + 128];
+                int r, g, b;
+                COMPUTE_CBCR(cb, cr);
+                WRITE_COLOR(d, y0, r, g, b);
+                d += XSTEP;
+            }
+
+            dest += stride;
+        }
+    }
+
+    MANGO_UNREFERENCED(state);
+    MANGO_UNREFERENCED(width);
+    MANGO_UNREFERENCED(height);
+}
+
 void FUNCTION_YCBCR_8x8(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
 {
     u8 result[64 * 3];
@@ -104,35 +138,51 @@ void FUNCTION_YCBCR_8x8(u8* dest, size_t stride, const s16* data, ProcessState* 
     state->idct(result + 64 * 1, data + 64 * 1, state->block[1].qt); // Cb
     state->idct(result + 64 * 2, data + 64 * 2, state->block[2].qt); // Cr
 
-    // color conversion
-    const u8* src = result;
-
-    for (int y = 0; y < 8; ++y)
-    {
-        const u8* s = src + y * 8;
-        u8* d = dest;
-
-        for (int x = 0; x < 8; ++x)
-        {
-            int y0 = s[x];
-            int cb = s[x + 64];
-            int cr = s[x + 128];
-            int r, g, b;
-            COMPUTE_CBCR(cb, cr);
-            WRITE_COLOR(d, y0, r, g, b);
-            d += XSTEP;
-        }
-
-        dest += stride;
-    }
-
-    MANGO_UNREFERENCED(width);
-    MANGO_UNREFERENCED(height);
+    JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x8)(dest, stride, result, state, width, height, 1, 0);
 }
 
 #endif
 
 #ifdef FUNCTION_YCBCR_8x16
+
+void JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x16)(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
+{
+    u8* origin = dest;
+
+    for (int m = 0; m < count; ++m)
+    {
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+
+        for (int y = 0; y < 8; ++y)
+        {
+            u8* d0 = dest;
+            u8* d1 = dest + stride;
+            const u8* s = result + y * 16;
+            const u8* c = result + y * 8 + 128;
+
+            for (int x = 0; x < 8; ++x)
+            {
+                int y0 = s[x + 0];
+                int y1 = s[x + 8];
+                int cb = c[x + 0];
+                int cr = c[x + 64];
+                int r, g, b;
+                COMPUTE_CBCR(cb, cr);
+                WRITE_COLOR(d0, y0, r, g, b);
+                WRITE_COLOR(d1, y1, r, g, b);
+                d0 += XSTEP;
+                d1 += XSTEP;
+            }
+
+            dest += stride * 2;
+        }
+    }
+
+    MANGO_UNREFERENCED(state);
+    MANGO_UNREFERENCED(width);
+    MANGO_UNREFERENCED(height);
+}
 
 void FUNCTION_YCBCR_8x16(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
 {
@@ -143,38 +193,62 @@ void FUNCTION_YCBCR_8x16(u8* dest, size_t stride, const s16* data, ProcessState*
     state->idct(result + 128, data + 128, state->block[2].qt); // Cb
     state->idct(result + 192, data + 192, state->block[3].qt); // Cr
 
-    // color conversion
-    for (int y = 0; y < 8; ++y)
-    {
-        u8* d0 = dest;
-        u8* d1 = dest + stride;
-        const u8* s = result + y * 16;
-        const u8* c = result + y * 8 + 128;
-
-        for (int x = 0; x < 8; ++x)
-        {
-            int y0 = s[x + 0];
-            int y1 = s[x + 8];
-            int cb = c[x + 0];
-            int cr = c[x + 64];
-            int r, g, b;
-            COMPUTE_CBCR(cb, cr);
-            WRITE_COLOR(d0, y0, r, g, b);
-            WRITE_COLOR(d1, y1, r, g, b);
-            d0 += XSTEP;
-            d1 += XSTEP;
-        }
-
-        dest += stride * 2;
-    }
-
-    MANGO_UNREFERENCED(width);
-    MANGO_UNREFERENCED(height);
+    JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x16)(dest, stride, result, state, width, height, 1, 0);
 }
 
 #endif
 
 #ifdef FUNCTION_YCBCR_16x8
+
+void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x8)(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
+{
+    u8* origin = dest;
+
+    for (int m = 0; m < count; ++m)
+    {
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+
+        for (int y = 0; y < 8; ++y)
+        {
+            u8* d = dest;
+            const u8* s = result + y * 8;
+            const u8* c = result + y * 8 + 128;
+
+            for (int x = 0; x < 4; ++x)
+            {
+                int y0 = s[x * 2 + 0];
+                int y1 = s[x * 2 + 1];
+                int cb = c[x + 0];
+                int cr = c[x + 64];
+                int r, g, b;
+                COMPUTE_CBCR(cb, cr);
+                WRITE_COLOR(d + 0 * XSTEP, y0, r, g, b);
+                WRITE_COLOR(d + 1 * XSTEP, y1, r, g, b);
+                d += 2 * XSTEP;
+            }
+
+            for (int x = 0; x < 4; ++x)
+            {
+                int y0 = s[x * 2 + 64];
+                int y1 = s[x * 2 + 65];
+                int cb = c[x + 4];
+                int cr = c[x + 68];
+                int r, g, b;
+                COMPUTE_CBCR(cb, cr);
+                WRITE_COLOR(d + 0 * XSTEP, y0, r, g, b);
+                WRITE_COLOR(d + 1 * XSTEP, y1, r, g, b);
+                d += 2 * XSTEP;
+            }
+
+            dest += stride;
+        }
+    }
+
+    MANGO_UNREFERENCED(state);
+    MANGO_UNREFERENCED(width);
+    MANGO_UNREFERENCED(height);
+}
 
 void FUNCTION_YCBCR_16x8(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
 {
@@ -185,49 +259,66 @@ void FUNCTION_YCBCR_16x8(u8* dest, size_t stride, const s16* data, ProcessState*
     state->idct(result + 128, data + 128, state->block[2].qt); // Cb
     state->idct(result + 192, data + 192, state->block[3].qt); // Cr
 
-    // color conversion
-    for (int y = 0; y < 8; ++y)
-    {
-        u8* d = dest;
-        u8* s = result + y * 8;
-        u8* c = result + y * 8 + 128;
-
-        for (int x = 0; x < 4; ++x)
-        {
-            int y0 = s[x * 2 + 0];
-            int y1 = s[x * 2 + 1];
-            int cb = c[x + 0];
-            int cr = c[x + 64];
-            int r, g, b;
-            COMPUTE_CBCR(cb, cr);
-            WRITE_COLOR(d + 0 * XSTEP, y0, r, g, b);
-            WRITE_COLOR(d + 1 * XSTEP, y1, r, g, b);
-            d += 2 * XSTEP;
-        }
-
-        for (int x = 0; x < 4; ++x)
-        {
-            int y0 = s[x * 2 + 64];
-            int y1 = s[x * 2 + 65];
-            int cb = c[x + 4];
-            int cr = c[x + 68];
-            int r, g, b;
-            COMPUTE_CBCR(cb, cr);
-            WRITE_COLOR(d + 0 * XSTEP, y0, r, g, b);
-            WRITE_COLOR(d + 1 * XSTEP, y1, r, g, b);
-            d += 2 * XSTEP;
-        }
-
-        dest += stride;
-    }
-
-    MANGO_UNREFERENCED(width);
-    MANGO_UNREFERENCED(height);
+    JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x8)(dest, stride, result, state, width, height, 1, 0);
 }
 
 #endif
 
 #ifdef FUNCTION_YCBCR_16x16
+
+void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x16)(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
+{
+    u8* origin = dest;
+
+    for (int m = 0; m < count; ++m)
+    {
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+
+        for (int i = 0; i < 4; ++i)
+        {
+            int cbcr_offset = (i & 1) * 4 + (i >> 1) * 32;
+            int y_offset = i * 64;
+            size_t dest_offset = (i >> 1) * 8 * stride + (i & 1) * 8 * XSTEP;
+            const u8* ptr_cbcr = result + 256 + cbcr_offset;
+            const u8* ptr_y = result + y_offset;
+            u8* ptr_dest = dest + dest_offset;
+
+            for (int y = 0; y < 4; ++y)
+            {
+                u8* scan = ptr_dest;
+
+                for (int x = 0; x < 4; ++x)
+                {
+                    u8 y0 = ptr_y[x * 2 + 0];
+                    u8 y1 = ptr_y[x * 2 + 1];
+                    u8 y2 = ptr_y[x * 2 + 8];
+                    u8 y3 = ptr_y[x * 2 + 9];
+                    u8 cb = ptr_cbcr[x + 0];
+                    u8 cr = ptr_cbcr[x + 64];
+
+                    int r, g, b;
+                    COMPUTE_CBCR(cb, cr);
+                    WRITE_COLOR(scan + 0 * XSTEP, y0, r, g, b);
+                    WRITE_COLOR(scan + 1 * XSTEP, y1, r, g, b);
+
+                    u8* next = scan + stride;
+                    scan += 2 * XSTEP;
+                    WRITE_COLOR(next + 0 * XSTEP, y2, r, g, b);
+                    WRITE_COLOR(next + 1 * XSTEP, y3, r, g, b);
+                }
+
+                ptr_dest += stride * 2;
+                ptr_y += 8 * 2;
+                ptr_cbcr += 8;
+            }
+        }
+    }
+
+    MANGO_UNREFERENCED(state);
+    MANGO_UNREFERENCED(width);
+    MANGO_UNREFERENCED(height);
+}
 
 void FUNCTION_YCBCR_16x16(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
 {
@@ -240,48 +331,7 @@ void FUNCTION_YCBCR_16x16(u8* dest, size_t stride, const s16* data, ProcessState
     state->idct(result + 256, data + 256, state->block[4].qt); // Cb
     state->idct(result + 320, data + 320, state->block[5].qt); // Cr
 
-    // color conversion
-    for (int i = 0; i < 4; ++i)
-    {
-        int cbcr_offset = (i & 1) * 4 + (i >> 1) * 32;
-        int y_offset = i * 64;
-        size_t dest_offset = (i >> 1) * 8 * stride + (i & 1) * 8 * XSTEP;
-        const u8* ptr_cbcr = result + 256 + cbcr_offset;
-        const u8* ptr_y = result + y_offset;
-        u8* ptr_dest = dest + dest_offset;
-
-        for (int y = 0; y < 4; ++y)
-        {
-            u8* scan = ptr_dest;
-
-            for (int x = 0; x < 4; ++x)
-            {
-                u8 y0 = ptr_y[x * 2 + 0];
-                u8 y1 = ptr_y[x * 2 + 1];
-                u8 y2 = ptr_y[x * 2 + 8];
-                u8 y3 = ptr_y[x * 2 + 9];
-                u8 cb = ptr_cbcr[x + 0];
-                u8 cr = ptr_cbcr[x + 64];
-
-                int r, g, b;
-                COMPUTE_CBCR(cb, cr);
-                WRITE_COLOR(scan + 0 * XSTEP, y0, r, g, b);
-                WRITE_COLOR(scan + 1 * XSTEP, y1, r, g, b);
-
-                u8* next = scan + stride;
-                scan += 2 * XSTEP;
-                WRITE_COLOR(next + 0 * XSTEP, y2, r, g, b);
-                WRITE_COLOR(next + 1 * XSTEP, y3, r, g, b);
-            }
-
-            ptr_dest += stride * 2;
-            ptr_y += 8 * 2;
-            ptr_cbcr += 8;
-        }
-    }
-
-    MANGO_UNREFERENCED(width);
-    MANGO_UNREFERENCED(height);
+    JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x16)(dest, stride, result, state, width, height, 1, 0);
 }
 
 #endif

--- a/source/mango/jpeg/jpeg_process_func.hpp
+++ b/source/mango/jpeg/jpeg_process_func.hpp
@@ -5,89 +5,87 @@
 
 #ifdef FUNCTION_GENERIC
 
-void FUNCTION_GENERIC(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
+void FUNCTION_GENERIC(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
 {
-    u8 result[JPEG_MAX_SAMPLES_IN_MCU];
-
-    for (int i = 0; i < state->blocks; ++i)
-    {
-        Block& block = state->block[i];
-        state->idct(result + i * 64, data, block.qt);
-        data += 64;
-    }
-
-    // MCU dimension in blocks
     int hmax = std::max(std::max(state->frame[0].hsf, state->frame[1].hsf), state->frame[2].hsf);
     int vmax = std::max(std::max(state->frame[0].vsf, state->frame[1].vsf), state->frame[2].vsf);
 
-    u8 temp[JPEG_MAX_SAMPLES_IN_MCU * 3];
+    u8* origin = dest;
 
-    // first pass: expand channel data
-    for (int channel = 0; channel < 3; ++channel)
+    for (int m = 0; m < count; ++m)
     {
-        int offset = state->frame[channel].offset * 64;
-        int hsf = state->frame[channel].hsf;
-        int vsf = state->frame[channel].vsf;
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
 
-        for (int yblock = 0; yblock < vsf; ++yblock)
+        u8 temp[JPEG_MAX_SAMPLES_IN_MCU * 3];
+
+        // first pass: expand channel data
+        for (int channel = 0; channel < 3; ++channel)
         {
-            for (int xblock = 0; xblock < hsf; ++xblock)
+            int offset = state->frame[channel].offset * 64;
+            int hsf = state->frame[channel].hsf;
+            int vsf = state->frame[channel].vsf;
+
+            for (int yblock = 0; yblock < vsf; ++yblock)
             {
-                u8* source = result + offset + (yblock * hsf + xblock) * 64;
-                u8* d = temp + channel * JPEG_MAX_SAMPLES_IN_MCU + yblock * 8 * (hmax * 8) + xblock * 8;
-
-                if (hmax != hsf || vmax != vsf)
+                for (int xblock = 0; xblock < hsf; ++xblock)
                 {
-                    int xscale = hmax / hsf;
-                    int yscale = vmax / vsf;
+                    const u8* source = result + offset + (yblock * hsf + xblock) * 64;
+                    u8* d = temp + channel * JPEG_MAX_SAMPLES_IN_MCU + yblock * 8 * (hmax * 8) + xblock * 8;
 
-                    for (int y = 0; y < 8; ++y)
+                    if (hmax != hsf || vmax != vsf)
                     {
-                        for (int x = 0; x < 8; ++x)
+                        int xscale = hmax / hsf;
+                        int yscale = vmax / vsf;
+
+                        for (int y = 0; y < 8; ++y)
                         {
-                            u8 sample = *source++;
-                            std::memset(d + x * xscale, sample, xscale);
+                            for (int x = 0; x < 8; ++x)
+                            {
+                                u8 sample = *source++;
+                                std::memset(d + x * xscale, sample, xscale);
+                            }
+
+                            d += hmax * 8;
+
+                            for (int s = 1; s < yscale; ++s)
+                            {
+                                std::memcpy(d, d - hmax * 8, xscale * 8);
+                                d += hmax * 8;
+                            }
                         }
-
-                        d += hmax * 8;
-
-                        for (int s = 1; s < yscale; ++s)
+                    }
+                    else
+                    {
+                        for (int y = 0; y < 8; ++y)
                         {
-                            std::memcpy(d, d - hmax * 8, xscale * 8);
+                            std::memcpy(d, source, 8);
+                            source += 8;
                             d += hmax * 8;
                         }
                     }
                 }
-                else
-                {
-                    for (int y = 0; y < 8; ++y)
-                    {
-                        std::memcpy(d, source, 8);
-                        source += 8;
-                        d += hmax * 8;
-                    }
-                }
             }
         }
-    }
 
-    // second pass: resolve color
-    for (int y = 0; y < height; ++y)
-    {
-        u8* source0 = temp + 0 * JPEG_MAX_SAMPLES_IN_MCU + (y * hmax * 8);
-        u8* source1 = temp + 1 * JPEG_MAX_SAMPLES_IN_MCU + (y * hmax * 8);
-        u8* source2 = temp + 2 * JPEG_MAX_SAMPLES_IN_MCU + (y * hmax * 8);
-        u8* d = dest + y * stride;
-
-        for (int x = 0; x < width; ++x)
+        // second pass: resolve color
+        for (int y = 0; y < height; ++y)
         {
-            u8 y0 = source0[x];
-            u8 cb = source1[x];
-            u8 cr = source2[x];
-            int r, g, b;
-            COMPUTE_CBCR(cb, cr);
-            WRITE_COLOR(d, y0, r, g, b);
-            d += XSTEP;
+            u8* source0 = temp + 0 * JPEG_MAX_SAMPLES_IN_MCU + (y * hmax * 8);
+            u8* source1 = temp + 1 * JPEG_MAX_SAMPLES_IN_MCU + (y * hmax * 8);
+            u8* source2 = temp + 2 * JPEG_MAX_SAMPLES_IN_MCU + (y * hmax * 8);
+            u8* d = dest + y * stride;
+
+            for (int x = 0; x < width; ++x)
+            {
+                u8 y0 = source0[x];
+                u8 cb = source1[x];
+                u8 cr = source2[x];
+                int r, g, b;
+                COMPUTE_CBCR(cb, cr);
+                WRITE_COLOR(d, y0, r, g, b);
+                d += XSTEP;
+            }
         }
     }
 }
@@ -128,17 +126,6 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x8)(u8* dest, size_t stride, const u8* spat
     MANGO_UNREFERENCED(state);
     MANGO_UNREFERENCED(width);
     MANGO_UNREFERENCED(height);
-}
-
-void FUNCTION_YCBCR_8x8(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
-{
-    u8 result[64 * 3];
-
-    state->idct(result + 64 * 0, data + 64 * 0, state->block[0].qt); // Y
-    state->idct(result + 64 * 1, data + 64 * 1, state->block[1].qt); // Cb
-    state->idct(result + 64 * 2, data + 64 * 2, state->block[2].qt); // Cr
-
-    JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x8)(dest, stride, result, state, width, height, 1, 0);
 }
 
 #endif
@@ -182,18 +169,6 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x16)(u8* dest, size_t stride, const u8* spa
     MANGO_UNREFERENCED(state);
     MANGO_UNREFERENCED(width);
     MANGO_UNREFERENCED(height);
-}
-
-void FUNCTION_YCBCR_8x16(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
-{
-    u8 result[64 * 4];
-
-    state->idct(result +   0, data +   0, state->block[0].qt); // Y0
-    state->idct(result +  64, data +  64, state->block[1].qt); // Y1
-    state->idct(result + 128, data + 128, state->block[2].qt); // Cb
-    state->idct(result + 192, data + 192, state->block[3].qt); // Cr
-
-    JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x16)(dest, stride, result, state, width, height, 1, 0);
 }
 
 #endif
@@ -248,18 +223,6 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x8)(u8* dest, size_t stride, const u8* spa
     MANGO_UNREFERENCED(state);
     MANGO_UNREFERENCED(width);
     MANGO_UNREFERENCED(height);
-}
-
-void FUNCTION_YCBCR_16x8(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
-{
-    u8 result[64 * 4];
-
-    state->idct(result +   0, data +   0, state->block[0].qt); // Y0
-    state->idct(result +  64, data +  64, state->block[1].qt); // Y1
-    state->idct(result + 128, data + 128, state->block[2].qt); // Cb
-    state->idct(result + 192, data + 192, state->block[3].qt); // Cr
-
-    JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x8)(dest, stride, result, state, width, height, 1, 0);
 }
 
 #endif
@@ -318,20 +281,6 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x16)(u8* dest, size_t stride, const u8* sp
     MANGO_UNREFERENCED(state);
     MANGO_UNREFERENCED(width);
     MANGO_UNREFERENCED(height);
-}
-
-void FUNCTION_YCBCR_16x16(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
-{
-    u8 result[64 * 6];
-
-    state->idct(result +   0, data +   0, state->block[0].qt); // Y0
-    state->idct(result +  64, data +  64, state->block[1].qt); // Y1
-    state->idct(result + 128, data + 128, state->block[2].qt); // Y2
-    state->idct(result + 192, data + 192, state->block[3].qt); // Y3
-    state->idct(result + 256, data + 256, state->block[4].qt); // Cb
-    state->idct(result + 320, data + 320, state->block[5].qt); // Cr
-
-    JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x16)(dest, stride, result, state, width, height, 1, 0);
 }
 
 #endif

--- a/source/mango/jpeg/jpeg_process_func.hpp
+++ b/source/mango/jpeg/jpeg_process_func.hpp
@@ -15,7 +15,7 @@ void FUNCTION_GENERIC(u8* dest, size_t stride, const u8* spatial, ProcessState* 
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         u8 temp[JPEG_MAX_SAMPLES_IN_MCU * 3];
 
@@ -101,7 +101,7 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x8)(u8* dest, size_t stride, const u8* spat
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int y = 0; y < 8; ++y)
         {
@@ -139,7 +139,7 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x16)(u8* dest, size_t stride, const u8* spa
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int y = 0; y < 8; ++y)
         {
@@ -182,7 +182,7 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x8)(u8* dest, size_t stride, const u8* spa
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int y = 0; y < 8; ++y)
         {
@@ -236,7 +236,7 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x16)(u8* dest, size_t stride, const u8* sp
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int i = 0; i < 4; ++i)
         {

--- a/source/mango/jpeg/jpeg_process_neon.hpp
+++ b/source/mango/jpeg/jpeg_process_neon.hpp
@@ -40,17 +40,6 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x8)(u8* dest, size_t stride, const u8* spat
     MANGO_UNREFERENCED(height);
 }
 
-void FUNCTION_YCBCR_8x8(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
-{
-    u8 result[64 * 3];
-
-    state->idct(result +   0, data +   0, state->block[0].qt); // Y
-    state->idct(result +  64, data +  64, state->block[1].qt); // Cb
-    state->idct(result + 128, data + 128, state->block[2].qt); // Cr
-
-    JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x8)(dest, stride, result, state, width, height, 1, 0);
-}
-
 #endif
 
 #ifdef FUNCTION_YCBCR_8x16
@@ -93,18 +82,6 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x16)(u8* dest, size_t stride, const u8* spa
     MANGO_UNREFERENCED(state);
     MANGO_UNREFERENCED(width);
     MANGO_UNREFERENCED(height);
-}
-
-void FUNCTION_YCBCR_8x16(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
-{
-    u8 result[64 * 4];
-
-    state->idct(result +   0, data +   0, state->block[0].qt); // Y0
-    state->idct(result +  64, data +  64, state->block[1].qt); // Y1
-    state->idct(result + 128, data + 128, state->block[2].qt); // Cb
-    state->idct(result + 192, data + 192, state->block[3].qt); // Cr
-
-    JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x16)(dest, stride, result, state, width, height, 1, 0);
 }
 
 #endif
@@ -150,18 +127,6 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x8)(u8* dest, size_t stride, const u8* spa
     MANGO_UNREFERENCED(state);
     MANGO_UNREFERENCED(width);
     MANGO_UNREFERENCED(height);
-}
-
-void FUNCTION_YCBCR_16x8(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
-{
-    u8 result[64 * 4];
-
-    state->idct(result +   0, data +   0, state->block[0].qt); // Y0
-    state->idct(result +  64, data +  64, state->block[1].qt); // Y1
-    state->idct(result + 128, data + 128, state->block[2].qt); // Cb
-    state->idct(result + 192, data + 192, state->block[3].qt); // Cr
-
-    JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x8)(dest, stride, result, state, width, height, 1, 0);
 }
 
 #endif
@@ -215,20 +180,6 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x16)(u8* dest, size_t stride, const u8* sp
     MANGO_UNREFERENCED(state);
     MANGO_UNREFERENCED(width);
     MANGO_UNREFERENCED(height);
-}
-
-void FUNCTION_YCBCR_16x16(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
-{
-    u8 result[64 * 6];
-
-    state->idct(result +   0, data +   0, state->block[0].qt); // Y0
-    state->idct(result + 128, data +  64, state->block[1].qt); // Y1
-    state->idct(result +  64, data + 128, state->block[2].qt); // Y2
-    state->idct(result + 192, data + 192, state->block[3].qt); // Y3
-    state->idct(result + 256, data + 256, state->block[4].qt); // Cb
-    state->idct(result + 320, data + 320, state->block[5].qt); // Cr
-
-    JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x16)(dest, stride, result, state, width, height, 1, 0);
 }
 
 #endif

--- a/source/mango/jpeg/jpeg_process_neon.hpp
+++ b/source/mango/jpeg/jpeg_process_neon.hpp
@@ -18,7 +18,7 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x8)(u8* dest, size_t stride, const u8* spat
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int y = 0; y < 8; ++y)
         {
@@ -57,7 +57,7 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x16)(u8* dest, size_t stride, const u8* spa
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int y = 0; y < 8; ++y)
         {
@@ -101,7 +101,7 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x8)(u8* dest, size_t stride, const u8* spa
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int y = 0; y < 8; ++y)
         {
@@ -146,7 +146,7 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x16)(u8* dest, size_t stride, const u8* sp
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int y = 0; y < 8; ++y)
         {

--- a/source/mango/jpeg/jpeg_process_neon.hpp
+++ b/source/mango/jpeg/jpeg_process_neon.hpp
@@ -5,6 +5,41 @@
 
 #ifdef FUNCTION_YCBCR_8x8
 
+void JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x8)(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
+{
+    const uint8x8_t tosigned = vdup_n_u8(0x80);
+    const int16x8_t s0 = vdupq_n_s16(JPEG_FIXED( 1.40200));
+    const int16x8_t s1 = vdupq_n_s16(JPEG_FIXED(-0.71414));
+    const int16x8_t s2 = vdupq_n_s16(JPEG_FIXED(-0.34414));
+    const int16x8_t s3 = vdupq_n_s16(JPEG_FIXED( 1.77200));
+
+    u8* origin = dest;
+
+    for (int m = 0; m < count; ++m)
+    {
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+
+        for (int y = 0; y < 8; ++y)
+        {
+            uint8x8_t u_y  = vld1_u8(result + y * 8 + 0);
+            uint8x8_t u_cb = vld1_u8(result + y * 8 + 64);
+            uint8x8_t u_cr = vld1_u8(result + y * 8 + 128);
+
+            int16x8_t s_y = vreinterpretq_s16_u16(vshll_n_u8(u_y, 4));
+            int16x8_t s_cb = vshll_n_s8(vreinterpret_s8_u8(vsub_u8(u_cb, tosigned)), 7);
+            int16x8_t s_cr = vshll_n_s8(vreinterpret_s8_u8(vsub_u8(u_cr, tosigned)), 7);
+
+            INNERLOOP_YCBCR(dest, s_y, s_cb, s_cr, s0, s1, s2, s3);
+            dest += stride;
+        }
+    }
+
+    MANGO_UNREFERENCED(state);
+    MANGO_UNREFERENCED(width);
+    MANGO_UNREFERENCED(height);
+}
+
 void FUNCTION_YCBCR_8x8(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
 {
     u8 result[64 * 3];
@@ -13,33 +48,52 @@ void FUNCTION_YCBCR_8x8(u8* dest, size_t stride, const s16* data, ProcessState* 
     state->idct(result +  64, data +  64, state->block[1].qt); // Cb
     state->idct(result + 128, data + 128, state->block[2].qt); // Cr
 
+    JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x8)(dest, stride, result, state, width, height, 1, 0);
+}
+
+#endif
+
+#ifdef FUNCTION_YCBCR_8x16
+
+void JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x16)(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
+{
     const uint8x8_t tosigned = vdup_n_u8(0x80);
     const int16x8_t s0 = vdupq_n_s16(JPEG_FIXED( 1.40200));
     const int16x8_t s1 = vdupq_n_s16(JPEG_FIXED(-0.71414));
     const int16x8_t s2 = vdupq_n_s16(JPEG_FIXED(-0.34414));
     const int16x8_t s3 = vdupq_n_s16(JPEG_FIXED( 1.77200));
 
-    for (int y = 0; y < 8; ++y)
+    u8* origin = dest;
+
+    for (int m = 0; m < count; ++m)
     {
-        uint8x8_t u_y  = vld1_u8(result + y * 8 + 0);
-        uint8x8_t u_cb = vld1_u8(result + y * 8 + 64);
-        uint8x8_t u_cr = vld1_u8(result + y * 8 + 128);
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
 
-        int16x8_t s_y = vreinterpretq_s16_u16(vshll_n_u8(u_y, 4));
-        int16x8_t s_cb = vshll_n_s8(vreinterpret_s8_u8(vsub_u8(u_cb, tosigned)), 7);
-        int16x8_t s_cr = vshll_n_s8(vreinterpret_s8_u8(vsub_u8(u_cr, tosigned)), 7);
+        for (int y = 0; y < 8; ++y)
+        {
+            uint8x8_t u_y0 = vld1_u8(result + y * 16 + 0);
+            uint8x8_t u_y1 = vld1_u8(result + y * 16 + 8);
+            uint8x8_t u_cb = vld1_u8(result + y * 8 + 128);
+            uint8x8_t u_cr = vld1_u8(result + y * 8 + 192);
 
-        INNERLOOP_YCBCR(dest, s_y, s_cb, s_cr, s0, s1, s2, s3);
-        dest += stride;
+            int16x8_t s_y0 = vreinterpretq_s16_u16(vshll_n_u8(u_y0, 4));
+            int16x8_t s_y1 = vreinterpretq_s16_u16(vshll_n_u8(u_y1, 4));
+            int16x8_t s_cb = vshll_n_s8(vreinterpret_s8_u8(vsub_u8(u_cb, tosigned)), 7);
+            int16x8_t s_cr = vshll_n_s8(vreinterpret_s8_u8(vsub_u8(u_cr, tosigned)), 7);
+
+            INNERLOOP_YCBCR(dest, s_y0, s_cb, s_cr, s0, s1, s2, s3);
+            dest += stride;
+
+            INNERLOOP_YCBCR(dest, s_y1, s_cb, s_cr, s0, s1, s2, s3);
+            dest += stride;
+        }
     }
 
+    MANGO_UNREFERENCED(state);
     MANGO_UNREFERENCED(width);
     MANGO_UNREFERENCED(height);
 }
-
-#endif
-
-#ifdef FUNCTION_YCBCR_8x16
 
 void FUNCTION_YCBCR_8x16(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
 {
@@ -50,38 +104,53 @@ void FUNCTION_YCBCR_8x16(u8* dest, size_t stride, const s16* data, ProcessState*
     state->idct(result + 128, data + 128, state->block[2].qt); // Cb
     state->idct(result + 192, data + 192, state->block[3].qt); // Cr
 
+    JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x16)(dest, stride, result, state, width, height, 1, 0);
+}
+
+#endif
+
+#ifdef FUNCTION_YCBCR_16x8
+
+void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x8)(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
+{
     const uint8x8_t tosigned = vdup_n_u8(0x80);
     const int16x8_t s0 = vdupq_n_s16(JPEG_FIXED( 1.40200));
     const int16x8_t s1 = vdupq_n_s16(JPEG_FIXED(-0.71414));
     const int16x8_t s2 = vdupq_n_s16(JPEG_FIXED(-0.34414));
     const int16x8_t s3 = vdupq_n_s16(JPEG_FIXED( 1.77200));
 
-    for (int y = 0; y < 8; ++y)
+    u8* origin = dest;
+
+    for (int m = 0; m < count; ++m)
     {
-        uint8x8_t u_y0 = vld1_u8(result + y * 16 + 0);
-        uint8x8_t u_y1 = vld1_u8(result + y * 16 + 8);
-        uint8x8_t u_cb = vld1_u8(result + y * 8 + 128);
-        uint8x8_t u_cr = vld1_u8(result + y * 8 + 192);
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
 
-        int16x8_t s_y0 = vreinterpretq_s16_u16(vshll_n_u8(u_y0, 4));
-        int16x8_t s_y1 = vreinterpretq_s16_u16(vshll_n_u8(u_y1, 4));
-        int16x8_t s_cb = vshll_n_s8(vreinterpret_s8_u8(vsub_u8(u_cb, tosigned)), 7);
-        int16x8_t s_cr = vshll_n_s8(vreinterpret_s8_u8(vsub_u8(u_cr, tosigned)), 7);
+        for (int y = 0; y < 8; ++y)
+        {
+            uint8x8_t u_y0 = vld1_u8(result + y * 8 + 0);
+            uint8x8_t u_y1 = vld1_u8(result + y * 8 + 64);
+            uint8x8_t u_cb = vld1_u8(result + y * 8 + 128);
+            uint8x8_t u_cr = vld1_u8(result + y * 8 + 192);
 
-        INNERLOOP_YCBCR(dest, s_y0, s_cb, s_cr, s0, s1, s2, s3);
-        dest += stride;
+            int16x8_t s_y0 = vreinterpretq_s16_u16(vshll_n_u8(u_y0, 4));
+            int16x8_t s_y1 = vreinterpretq_s16_u16(vshll_n_u8(u_y1, 4));
+            int16x8_t s_cb = vshll_n_s8(vreinterpret_s8_u8(vsub_u8(u_cb, tosigned)), 7);
+            int16x8_t s_cr = vshll_n_s8(vreinterpret_s8_u8(vsub_u8(u_cr, tosigned)), 7);
 
-        INNERLOOP_YCBCR(dest, s_y1, s_cb, s_cr, s0, s1, s2, s3);
-        dest += stride;
+            int16x8x2_t w_cb = vzipq_s16(s_cb, s_cb);
+            int16x8x2_t w_cr = vzipq_s16(s_cr, s_cr);
+
+            INNERLOOP_YCBCR(dest + 0 * XSTEP, s_y0, w_cb.val[0], w_cr.val[0], s0, s1, s2, s3);
+            INNERLOOP_YCBCR(dest + 1 * XSTEP, s_y1, w_cb.val[1], w_cr.val[1], s0, s1, s2, s3);
+            dest += stride;
+        }
     }
 
+    MANGO_UNREFERENCED(state);
     MANGO_UNREFERENCED(width);
     MANGO_UNREFERENCED(height);
 }
-
-#endif
-
-#ifdef FUNCTION_YCBCR_16x8
 
 void FUNCTION_YCBCR_16x8(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
 {
@@ -92,39 +161,61 @@ void FUNCTION_YCBCR_16x8(u8* dest, size_t stride, const s16* data, ProcessState*
     state->idct(result + 128, data + 128, state->block[2].qt); // Cb
     state->idct(result + 192, data + 192, state->block[3].qt); // Cr
 
+    JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x8)(dest, stride, result, state, width, height, 1, 0);
+}
+
+#endif
+
+#ifdef FUNCTION_YCBCR_16x16
+
+void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x16)(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
+{
     const uint8x8_t tosigned = vdup_n_u8(0x80);
     const int16x8_t s0 = vdupq_n_s16(JPEG_FIXED( 1.40200));
     const int16x8_t s1 = vdupq_n_s16(JPEG_FIXED(-0.71414));
     const int16x8_t s2 = vdupq_n_s16(JPEG_FIXED(-0.34414));
     const int16x8_t s3 = vdupq_n_s16(JPEG_FIXED( 1.77200));
 
-    for (int y = 0; y < 8; ++y)
+    u8* origin = dest;
+
+    for (int m = 0; m < count; ++m)
     {
-        uint8x8_t u_y0 = vld1_u8(result + y * 8 + 0);
-        uint8x8_t u_y1 = vld1_u8(result + y * 8 + 64);
-        uint8x8_t u_cb = vld1_u8(result + y * 8 + 128);
-        uint8x8_t u_cr = vld1_u8(result + y * 8 + 192);
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
 
-        int16x8_t s_y0 = vreinterpretq_s16_u16(vshll_n_u8(u_y0, 4));
-        int16x8_t s_y1 = vreinterpretq_s16_u16(vshll_n_u8(u_y1, 4));
-        int16x8_t s_cb = vshll_n_s8(vreinterpret_s8_u8(vsub_u8(u_cb, tosigned)), 7);
-        int16x8_t s_cr = vshll_n_s8(vreinterpret_s8_u8(vsub_u8(u_cr, tosigned)), 7);
+        for (int y = 0; y < 8; ++y)
+        {
+            uint8x8_t u_y0 = vld1_u8(result + y * 16 + 0);
+            uint8x8_t u_y1 = vld1_u8(result + y * 16 + 128);
+            uint8x8_t u_y2 = vld1_u8(result + y * 16 + 8);
+            uint8x8_t u_y3 = vld1_u8(result + y * 16 + 136);
+            uint8x8_t u_cb = vld1_u8(result + y * 8 + 256);
+            uint8x8_t u_cr = vld1_u8(result + y * 8 + 320);
 
-        int16x8x2_t w_cb = vzipq_s16(s_cb, s_cb);
-        int16x8x2_t w_cr = vzipq_s16(s_cr, s_cr);
+            int16x8_t s_y0 = vreinterpretq_s16_u16(vshll_n_u8(u_y0, 4));
+            int16x8_t s_y1 = vreinterpretq_s16_u16(vshll_n_u8(u_y1, 4));
+            int16x8_t s_y2 = vreinterpretq_s16_u16(vshll_n_u8(u_y2, 4));
+            int16x8_t s_y3 = vreinterpretq_s16_u16(vshll_n_u8(u_y3, 4));
+            int16x8_t s_cb = vshll_n_s8(vreinterpret_s8_u8(vsub_u8(u_cb, tosigned)), 7);
+            int16x8_t s_cr = vshll_n_s8(vreinterpret_s8_u8(vsub_u8(u_cr, tosigned)), 7);
 
-        INNERLOOP_YCBCR(dest + 0 * XSTEP, s_y0, w_cb.val[0], w_cr.val[0], s0, s1, s2, s3);
-        INNERLOOP_YCBCR(dest + 1 * XSTEP, s_y1, w_cb.val[1], w_cr.val[1], s0, s1, s2, s3);
-        dest += stride;
+            int16x8x2_t w_cb = vzipq_s16(s_cb, s_cb);
+            int16x8x2_t w_cr = vzipq_s16(s_cr, s_cr);
+
+            INNERLOOP_YCBCR(dest + 0 * XSTEP, s_y0, w_cb.val[0], w_cr.val[0], s0, s1, s2, s3);
+            INNERLOOP_YCBCR(dest + 1 * XSTEP, s_y1, w_cb.val[1], w_cr.val[1], s0, s1, s2, s3);
+            dest += stride;
+
+            INNERLOOP_YCBCR(dest + 0 * XSTEP, s_y2, w_cb.val[0], w_cr.val[0], s0, s1, s2, s3);
+            INNERLOOP_YCBCR(dest + 1 * XSTEP, s_y3, w_cb.val[1], w_cr.val[1], s0, s1, s2, s3);
+            dest += stride;
+        }
     }
 
+    MANGO_UNREFERENCED(state);
     MANGO_UNREFERENCED(width);
     MANGO_UNREFERENCED(height);
 }
-
-#endif
-
-#ifdef FUNCTION_YCBCR_16x16
 
 void FUNCTION_YCBCR_16x16(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
 {
@@ -137,42 +228,7 @@ void FUNCTION_YCBCR_16x16(u8* dest, size_t stride, const s16* data, ProcessState
     state->idct(result + 256, data + 256, state->block[4].qt); // Cb
     state->idct(result + 320, data + 320, state->block[5].qt); // Cr
 
-    const uint8x8_t tosigned = vdup_n_u8(0x80);
-    const int16x8_t s0 = vdupq_n_s16(JPEG_FIXED( 1.40200));
-    const int16x8_t s1 = vdupq_n_s16(JPEG_FIXED(-0.71414));
-    const int16x8_t s2 = vdupq_n_s16(JPEG_FIXED(-0.34414));
-    const int16x8_t s3 = vdupq_n_s16(JPEG_FIXED( 1.77200));
-
-    for (int y = 0; y < 8; ++y)
-    {
-        uint8x8_t u_y0 = vld1_u8(result + y * 16 + 0);
-        uint8x8_t u_y1 = vld1_u8(result + y * 16 + 128);
-        uint8x8_t u_y2 = vld1_u8(result + y * 16 + 8);
-        uint8x8_t u_y3 = vld1_u8(result + y * 16 + 136);
-        uint8x8_t u_cb = vld1_u8(result + y * 8 + 256);
-        uint8x8_t u_cr = vld1_u8(result + y * 8 + 320);
-
-        int16x8_t s_y0 = vreinterpretq_s16_u16(vshll_n_u8(u_y0, 4));
-        int16x8_t s_y1 = vreinterpretq_s16_u16(vshll_n_u8(u_y1, 4));
-        int16x8_t s_y2 = vreinterpretq_s16_u16(vshll_n_u8(u_y2, 4));
-        int16x8_t s_y3 = vreinterpretq_s16_u16(vshll_n_u8(u_y3, 4));
-        int16x8_t s_cb = vshll_n_s8(vreinterpret_s8_u8(vsub_u8(u_cb, tosigned)), 7);
-        int16x8_t s_cr = vshll_n_s8(vreinterpret_s8_u8(vsub_u8(u_cr, tosigned)), 7);
-
-        int16x8x2_t w_cb = vzipq_s16(s_cb, s_cb);
-        int16x8x2_t w_cr = vzipq_s16(s_cr, s_cr);
-
-        INNERLOOP_YCBCR(dest + 0 * XSTEP, s_y0, w_cb.val[0], w_cr.val[0], s0, s1, s2, s3);
-        INNERLOOP_YCBCR(dest + 1 * XSTEP, s_y1, w_cb.val[1], w_cr.val[1], s0, s1, s2, s3);
-        dest += stride;
-
-        INNERLOOP_YCBCR(dest + 0 * XSTEP, s_y2, w_cb.val[0], w_cr.val[0], s0, s1, s2, s3);
-        INNERLOOP_YCBCR(dest + 1 * XSTEP, s_y3, w_cb.val[1], w_cr.val[1], s0, s1, s2, s3);
-        dest += stride;
-    }
-
-    MANGO_UNREFERENCED(width);
-    MANGO_UNREFERENCED(height);
+    JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x16)(dest, stride, result, state, width, height, 1, 0);
 }
 
 #endif

--- a/source/mango/jpeg/jpeg_process_neon.hpp
+++ b/source/mango/jpeg/jpeg_process_neon.hpp
@@ -1,6 +1,6 @@
 /*
     MANGO Multimedia Development Platform
-    Copyright (C) 2012-2023 Twilight Finland 3D Oy Ltd. All rights reserved.
+    Copyright (C) 2012-2026 Twilight Finland 3D Oy Ltd. All rights reserved.
 */
 
 #ifdef FUNCTION_YCBCR_8x8
@@ -150,10 +150,11 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x16)(u8* dest, size_t stride, const u8* sp
 
         for (int y = 0; y < 8; ++y)
         {
-            uint8x8_t u_y0 = vld1_u8(result + y * 16 + 0);
-            uint8x8_t u_y1 = vld1_u8(result + y * 16 + 128);
-            uint8x8_t u_y2 = vld1_u8(result + y * 16 + 8);
-            uint8x8_t u_y3 = vld1_u8(result + y * 16 + 136);
+            const int y_base = (y >> 2) * 128 + (y & 3) * 16;
+            uint8x8_t u_y0 = vld1_u8(result + y_base + 0);
+            uint8x8_t u_y1 = vld1_u8(result + y_base + 64);
+            uint8x8_t u_y2 = vld1_u8(result + y_base + 8);
+            uint8x8_t u_y3 = vld1_u8(result + y_base + 72);
             uint8x8_t u_cb = vld1_u8(result + y * 8 + 256);
             uint8x8_t u_cr = vld1_u8(result + y * 8 + 320);
 

--- a/source/mango/jpeg/jpeg_process_sse2.hpp
+++ b/source/mango/jpeg/jpeg_process_sse2.hpp
@@ -1,6 +1,6 @@
 /*
     MANGO Multimedia Development Platform
-    Copyright (C) 2012-2023 Twilight Finland 3D Oy Ltd. All rights reserved.
+    Copyright (C) 2012-2026 Twilight Finland 3D Oy Ltd. All rights reserved.
 */
 
 #ifdef FUNCTION_YCBCR_8x8
@@ -206,10 +206,11 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x16)(u8* dest, size_t stride, const u8* sp
 
         for (int y = 0; y < 4; ++y)
         {
-            __m128i y0 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 32 + 0));
-            __m128i y1 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 32 + 128));
-            __m128i y2 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 32 + 16));
-            __m128i y3 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 32 + 144));
+            const int y_base = (y >> 1) * 128 + (y & 1) * 32;
+            __m128i y0 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y_base + 0));
+            __m128i y1 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y_base + 64));
+            __m128i y2 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y_base + 16));
+            __m128i y3 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y_base + 80));
             __m128i cb = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 256));
             __m128i cr = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 320));
 

--- a/source/mango/jpeg/jpeg_process_sse2.hpp
+++ b/source/mango/jpeg/jpeg_process_sse2.hpp
@@ -19,7 +19,7 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x8)(u8* dest, size_t stride, const u8* spat
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int y = 0; y < 4; ++y)
         {
@@ -70,7 +70,7 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x16)(u8* dest, size_t stride, const u8* spa
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int y = 0; y < 4; ++y)
         {
@@ -128,7 +128,7 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x8)(u8* dest, size_t stride, const u8* spa
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int y = 0; y < 4; ++y)
         {
@@ -202,7 +202,7 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x16)(u8* dest, size_t stride, const u8* sp
     for (int m = 0; m < count; ++m)
     {
         dest = origin + m * xstride;
-        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+        const u8* result = spatial + m * state->spatialMCUBytes();
 
         for (int y = 0; y < 4; ++y)
         {

--- a/source/mango/jpeg/jpeg_process_sse2.hpp
+++ b/source/mango/jpeg/jpeg_process_sse2.hpp
@@ -5,6 +5,53 @@
 
 #ifdef FUNCTION_YCBCR_8x8
 
+void JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x8)(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
+{
+    // color conversion
+    const __m128i s0 = JPEG_CONST_SSE2(JPEG_FIXED( 1.00000), JPEG_FIXED( 1.40200));
+    const __m128i s1 = JPEG_CONST_SSE2(JPEG_FIXED( 1.00000), JPEG_FIXED( 1.77200));
+    const __m128i s2 = JPEG_CONST_SSE2(JPEG_FIXED(-0.34414), JPEG_FIXED(-0.71414));
+    const __m128i rounding = _mm_set1_epi32(1 << (JPEG_PREC - 1));
+    const __m128i tosigned = _mm_set1_epi16(128);
+
+    u8* origin = dest;
+
+    for (int m = 0; m < count; ++m)
+    {
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
+
+        for (int y = 0; y < 4; ++y)
+        {
+            __m128i y0 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 0));
+            __m128i cb = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 64));
+            __m128i cr = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 128));
+
+            __m128i zero = _mm_setzero_si128();
+
+            __m128i cb0 = _mm_unpacklo_epi8(cb, zero);
+            __m128i cr0 = _mm_unpacklo_epi8(cr, zero);
+            __m128i cb1 = _mm_unpackhi_epi8(cb, zero);
+            __m128i cr1 = _mm_unpackhi_epi8(cr, zero);
+
+            cb0 = _mm_sub_epi16(cb0, tosigned);
+            cr0 = _mm_sub_epi16(cr0, tosigned);
+            cb1 = _mm_sub_epi16(cb1, tosigned);
+            cr1 = _mm_sub_epi16(cr1, tosigned);
+
+            INNERLOOP_YCBCR(dest, _mm_unpacklo_epi8(y0, zero), cb0, cr0, s0, s1, s2, rounding);
+            dest += stride;
+
+            INNERLOOP_YCBCR(dest, _mm_unpackhi_epi8(y0, zero), cb1, cr1, s0, s1, s2, rounding);
+            dest += stride;
+        }
+    }
+
+    MANGO_UNREFERENCED(state);
+    MANGO_UNREFERENCED(width);
+    MANGO_UNREFERENCED(height);
+}
+
 void FUNCTION_YCBCR_8x8(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
 {
     u8 result[64 * 3];
@@ -13,6 +60,15 @@ void FUNCTION_YCBCR_8x8(u8* dest, size_t stride, const s16* data, ProcessState* 
     state->idct(result +  64, data +  64, state->block[1].qt); // Cb
     state->idct(result + 128, data + 128, state->block[2].qt); // Cr
 
+    JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x8)(dest, stride, result, state, width, height, 1, 0);
+}
+
+#endif
+
+#ifdef FUNCTION_YCBCR_8x16
+
+void JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x16)(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
+{
     // color conversion
     const __m128i s0 = JPEG_CONST_SSE2(JPEG_FIXED( 1.00000), JPEG_FIXED( 1.40200));
     const __m128i s1 = JPEG_CONST_SSE2(JPEG_FIXED( 1.00000), JPEG_FIXED( 1.77200));
@@ -20,38 +76,50 @@ void FUNCTION_YCBCR_8x8(u8* dest, size_t stride, const s16* data, ProcessState* 
     const __m128i rounding = _mm_set1_epi32(1 << (JPEG_PREC - 1));
     const __m128i tosigned = _mm_set1_epi16(128);
 
-    for (int y = 0; y < 4; ++y)
+    u8* origin = dest;
+
+    for (int m = 0; m < count; ++m)
     {
-        __m128i y0 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 0));
-        __m128i cb = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 64));
-        __m128i cr = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 128));
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
 
-        __m128i zero = _mm_setzero_si128();
+        for (int y = 0; y < 4; ++y)
+        {
+            __m128i y0 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 32 + 0));
+            __m128i y1 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 32 + 16));
+            __m128i cb = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 128));
+            __m128i cr = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 192));
 
-        __m128i cb0 = _mm_unpacklo_epi8(cb, zero);
-        __m128i cr0 = _mm_unpacklo_epi8(cr, zero);
-        __m128i cb1 = _mm_unpackhi_epi8(cb, zero);
-        __m128i cr1 = _mm_unpackhi_epi8(cr, zero);
+            __m128i zero = _mm_setzero_si128();
 
-        cb0 = _mm_sub_epi16(cb0, tosigned);
-        cr0 = _mm_sub_epi16(cr0, tosigned);
-        cb1 = _mm_sub_epi16(cb1, tosigned);
-        cr1 = _mm_sub_epi16(cr1, tosigned);
+            __m128i cb0 = _mm_unpacklo_epi8(cb, zero);
+            __m128i cr0 = _mm_unpacklo_epi8(cr, zero);
+            __m128i cb1 = _mm_unpackhi_epi8(cb, zero);
+            __m128i cr1 = _mm_unpackhi_epi8(cr, zero);
 
-        INNERLOOP_YCBCR(dest, _mm_unpacklo_epi8(y0, zero), cb0, cr0, s0, s1, s2, rounding);
-        dest += stride;
+            cb0 = _mm_sub_epi16(cb0, tosigned);
+            cr0 = _mm_sub_epi16(cr0, tosigned);
+            cb1 = _mm_sub_epi16(cb1, tosigned);
+            cr1 = _mm_sub_epi16(cr1, tosigned);
 
-        INNERLOOP_YCBCR(dest, _mm_unpackhi_epi8(y0, zero), cb1, cr1, s0, s1, s2, rounding);
-        dest += stride;
+            INNERLOOP_YCBCR(dest, _mm_unpacklo_epi8(y0, zero), cb0, cr0, s0, s1, s2, rounding);
+            dest += stride;
+
+            INNERLOOP_YCBCR(dest, _mm_unpackhi_epi8(y0, zero), cb0, cr0, s0, s1, s2, rounding);
+            dest += stride;
+
+            INNERLOOP_YCBCR(dest, _mm_unpacklo_epi8(y1, zero), cb1, cr1, s0, s1, s2, rounding);
+            dest += stride;
+
+            INNERLOOP_YCBCR(dest, _mm_unpackhi_epi8(y1, zero), cb1, cr1, s0, s1, s2, rounding);
+            dest += stride;
+        }
     }
 
+    MANGO_UNREFERENCED(state);
     MANGO_UNREFERENCED(width);
     MANGO_UNREFERENCED(height);
 }
-
-#endif
-
-#ifdef FUNCTION_YCBCR_8x16
 
 void FUNCTION_YCBCR_8x16(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
 {
@@ -62,6 +130,15 @@ void FUNCTION_YCBCR_8x16(u8* dest, size_t stride, const s16* data, ProcessState*
     state->idct(result + 128, data + 128, state->block[2].qt); // Cb
     state->idct(result + 192, data + 192, state->block[3].qt); // Cr
 
+    JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x16)(dest, stride, result, state, width, height, 1, 0);
+}
+
+#endif
+
+#ifdef FUNCTION_YCBCR_16x8
+
+void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x8)(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
+{
     // color conversion
     const __m128i s0 = JPEG_CONST_SSE2(JPEG_FIXED( 1.00000), JPEG_FIXED( 1.40200));
     const __m128i s1 = JPEG_CONST_SSE2(JPEG_FIXED( 1.00000), JPEG_FIXED( 1.77200));
@@ -69,45 +146,66 @@ void FUNCTION_YCBCR_8x16(u8* dest, size_t stride, const s16* data, ProcessState*
     const __m128i rounding = _mm_set1_epi32(1 << (JPEG_PREC - 1));
     const __m128i tosigned = _mm_set1_epi16(128);
 
-    for (int y = 0; y < 4; ++y)
+    u8* origin = dest;
+
+    for (int m = 0; m < count; ++m)
     {
-        __m128i y0 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 32 + 0));
-        __m128i y1 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 32 + 16));
-        __m128i cb = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 128));
-        __m128i cr = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 192));
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
 
-        __m128i zero = _mm_setzero_si128();
+        for (int y = 0; y < 4; ++y)
+        {
+            __m128i y0 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 0));
+            __m128i y1 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 64));
+            __m128i cb = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 128));
+            __m128i cr = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 192));
 
-        __m128i cb0 = _mm_unpacklo_epi8(cb, zero);
-        __m128i cr0 = _mm_unpacklo_epi8(cr, zero);
-        __m128i cb1 = _mm_unpackhi_epi8(cb, zero);
-        __m128i cr1 = _mm_unpackhi_epi8(cr, zero);
+            __m128i zero = _mm_setzero_si128();
+            __m128i cb0;
+            __m128i cb1;
+            __m128i cr0;
+            __m128i cr1;
 
-        cb0 = _mm_sub_epi16(cb0, tosigned);
-        cr0 = _mm_sub_epi16(cr0, tosigned);
-        cb1 = _mm_sub_epi16(cb1, tosigned);
-        cr1 = _mm_sub_epi16(cr1, tosigned);
+            cb0 = _mm_unpacklo_epi8(cb, cb);
+            cr0 = _mm_unpacklo_epi8(cr, cr);
 
-        INNERLOOP_YCBCR(dest, _mm_unpacklo_epi8(y0, zero), cb0, cr0, s0, s1, s2, rounding);
-        dest += stride;
+            cb1 = _mm_unpackhi_epi8(cb0, zero);
+            cr1 = _mm_unpackhi_epi8(cr0, zero);
+            cb0 = _mm_unpacklo_epi8(cb0, zero);
+            cr0 = _mm_unpacklo_epi8(cr0, zero);
 
-        INNERLOOP_YCBCR(dest, _mm_unpackhi_epi8(y0, zero), cb0, cr0, s0, s1, s2, rounding);
-        dest += stride;
+            cb0 = _mm_sub_epi16(cb0, tosigned);
+            cr0 = _mm_sub_epi16(cr0, tosigned);
+            cb1 = _mm_sub_epi16(cb1, tosigned);
+            cr1 = _mm_sub_epi16(cr1, tosigned);
 
-        INNERLOOP_YCBCR(dest, _mm_unpacklo_epi8(y1, zero), cb1, cr1, s0, s1, s2, rounding);
-        dest += stride;
+            INNERLOOP_YCBCR(dest + 0 * XSTEP, _mm_unpacklo_epi8(y0, zero), cb0, cr0, s0, s1, s2, rounding);
+            INNERLOOP_YCBCR(dest + 1 * XSTEP, _mm_unpacklo_epi8(y1, zero), cb1, cr1, s0, s1, s2, rounding);
+            dest += stride;
 
-        INNERLOOP_YCBCR(dest, _mm_unpackhi_epi8(y1, zero), cb1, cr1, s0, s1, s2, rounding);
-        dest += stride;
+            cb0 = _mm_unpackhi_epi8(cb, cb);
+            cr0 = _mm_unpackhi_epi8(cr, cr);
+
+            cb1 = _mm_unpackhi_epi8(cb0, zero);
+            cr1 = _mm_unpackhi_epi8(cr0, zero);
+            cb0 = _mm_unpacklo_epi8(cb0, zero);
+            cr0 = _mm_unpacklo_epi8(cr0, zero);
+
+            cb0 = _mm_sub_epi16(cb0, tosigned);
+            cr0 = _mm_sub_epi16(cr0, tosigned);
+            cb1 = _mm_sub_epi16(cb1, tosigned);
+            cr1 = _mm_sub_epi16(cr1, tosigned);
+
+            INNERLOOP_YCBCR(dest + 0 * XSTEP, _mm_unpackhi_epi8(y0, zero), cb0, cr0, s0, s1, s2, rounding);
+            INNERLOOP_YCBCR(dest + 1 * XSTEP, _mm_unpackhi_epi8(y1, zero), cb1, cr1, s0, s1, s2, rounding);
+            dest += stride;
+        }
     }
 
+    MANGO_UNREFERENCED(state);
     MANGO_UNREFERENCED(width);
     MANGO_UNREFERENCED(height);
 }
-
-#endif
-
-#ifdef FUNCTION_YCBCR_16x8
 
 void FUNCTION_YCBCR_16x8(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
 {
@@ -118,6 +216,15 @@ void FUNCTION_YCBCR_16x8(u8* dest, size_t stride, const s16* data, ProcessState*
     state->idct(result + 128, data + 128, state->block[2].qt); // Cb
     state->idct(result + 192, data + 192, state->block[3].qt); // Cr
 
+    JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x8)(dest, stride, result, state, width, height, 1, 0);
+}
+
+#endif
+
+#ifdef FUNCTION_YCBCR_16x16
+
+void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x16)(u8* dest, size_t stride, const u8* spatial, ProcessState* state, int width, int height, int count, size_t xstride)
+{
     // color conversion
     const __m128i s0 = JPEG_CONST_SSE2(JPEG_FIXED( 1.00000), JPEG_FIXED( 1.40200));
     const __m128i s1 = JPEG_CONST_SSE2(JPEG_FIXED( 1.00000), JPEG_FIXED( 1.77200));
@@ -125,61 +232,76 @@ void FUNCTION_YCBCR_16x8(u8* dest, size_t stride, const s16* data, ProcessState*
     const __m128i rounding = _mm_set1_epi32(1 << (JPEG_PREC - 1));
     const __m128i tosigned = _mm_set1_epi16(128);
 
-    for (int y = 0; y < 4; ++y)
+    u8* origin = dest;
+
+    for (int m = 0; m < count; ++m)
     {
-        __m128i y0 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 0));
-        __m128i y1 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 64));
-        __m128i cb = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 128));
-        __m128i cr = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 192));
+        dest = origin + m * xstride;
+        const u8* result = spatial + m * JPEG_MAX_SAMPLES_IN_MCU;
 
-        __m128i zero = _mm_setzero_si128();
-        __m128i cb0;
-        __m128i cb1;
-        __m128i cr0;
-        __m128i cr1;
+        for (int y = 0; y < 4; ++y)
+        {
+            __m128i y0 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 32 + 0));
+            __m128i y1 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 32 + 128));
+            __m128i y2 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 32 + 16));
+            __m128i y3 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 32 + 144));
+            __m128i cb = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 256));
+            __m128i cr = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 320));
 
-        cb0 = _mm_unpacklo_epi8(cb, cb);
-        cr0 = _mm_unpacklo_epi8(cr, cr);
+            __m128i zero = _mm_setzero_si128();
+            __m128i cb0;
+            __m128i cb1;
+            __m128i cr0;
+            __m128i cr1;
 
-        cb1 = _mm_unpackhi_epi8(cb0, zero);
-        cr1 = _mm_unpackhi_epi8(cr0, zero);
-        cb0 = _mm_unpacklo_epi8(cb0, zero);
-        cr0 = _mm_unpacklo_epi8(cr0, zero);
+            cb0 = _mm_unpacklo_epi8(cb, cb);
+            cr0 = _mm_unpacklo_epi8(cr, cr);
 
-        cb0 = _mm_sub_epi16(cb0, tosigned);
-        cr0 = _mm_sub_epi16(cr0, tosigned);
-        cb1 = _mm_sub_epi16(cb1, tosigned);
-        cr1 = _mm_sub_epi16(cr1, tosigned);
+            cb1 = _mm_unpackhi_epi8(cb0, zero);
+            cr1 = _mm_unpackhi_epi8(cr0, zero);
+            cb0 = _mm_unpacklo_epi8(cb0, zero);
+            cr0 = _mm_unpacklo_epi8(cr0, zero);
 
-        INNERLOOP_YCBCR(dest + 0 * XSTEP, _mm_unpacklo_epi8(y0, zero), cb0, cr0, s0, s1, s2, rounding);
-        INNERLOOP_YCBCR(dest + 1 * XSTEP, _mm_unpacklo_epi8(y1, zero), cb1, cr1, s0, s1, s2, rounding);
-        dest += stride;
+            cb0 = _mm_sub_epi16(cb0, tosigned);
+            cr0 = _mm_sub_epi16(cr0, tosigned);
+            cb1 = _mm_sub_epi16(cb1, tosigned);
+            cr1 = _mm_sub_epi16(cr1, tosigned);
 
-        cb0 = _mm_unpackhi_epi8(cb, cb);
-        cr0 = _mm_unpackhi_epi8(cr, cr);
+            INNERLOOP_YCBCR(dest + 0 * XSTEP, _mm_unpacklo_epi8(y0, zero), cb0, cr0, s0, s1, s2, rounding);
+            INNERLOOP_YCBCR(dest + 1 * XSTEP, _mm_unpacklo_epi8(y1, zero), cb1, cr1, s0, s1, s2, rounding);
+            dest += stride;
 
-        cb1 = _mm_unpackhi_epi8(cb0, zero);
-        cr1 = _mm_unpackhi_epi8(cr0, zero);
-        cb0 = _mm_unpacklo_epi8(cb0, zero);
-        cr0 = _mm_unpacklo_epi8(cr0, zero);
+            INNERLOOP_YCBCR(dest + 0 * XSTEP, _mm_unpackhi_epi8(y0, zero), cb0, cr0, s0, s1, s2, rounding);
+            INNERLOOP_YCBCR(dest + 1 * XSTEP, _mm_unpackhi_epi8(y1, zero), cb1, cr1, s0, s1, s2, rounding);
+            dest += stride;
 
-        cb0 = _mm_sub_epi16(cb0, tosigned);
-        cr0 = _mm_sub_epi16(cr0, tosigned);
-        cb1 = _mm_sub_epi16(cb1, tosigned);
-        cr1 = _mm_sub_epi16(cr1, tosigned);
+            cb0 = _mm_unpackhi_epi8(cb, cb);
+            cr0 = _mm_unpackhi_epi8(cr, cr);
 
-        INNERLOOP_YCBCR(dest + 0 * XSTEP, _mm_unpackhi_epi8(y0, zero), cb0, cr0, s0, s1, s2, rounding);
-        INNERLOOP_YCBCR(dest + 1 * XSTEP, _mm_unpackhi_epi8(y1, zero), cb1, cr1, s0, s1, s2, rounding);
-        dest += stride;
+            cb1 = _mm_unpackhi_epi8(cb0, zero);
+            cr1 = _mm_unpackhi_epi8(cr0, zero);
+            cb0 = _mm_unpacklo_epi8(cb0, zero);
+            cr0 = _mm_unpacklo_epi8(cr0, zero);
+
+            cb0 = _mm_sub_epi16(cb0, tosigned);
+            cr0 = _mm_sub_epi16(cr0, tosigned);
+            cb1 = _mm_sub_epi16(cb1, tosigned);
+            cr1 = _mm_sub_epi16(cr1, tosigned);
+
+            INNERLOOP_YCBCR(dest + 0 * XSTEP, _mm_unpacklo_epi8(y2, zero), cb0, cr0, s0, s1, s2, rounding);
+            INNERLOOP_YCBCR(dest + 1 * XSTEP, _mm_unpacklo_epi8(y3, zero), cb1, cr1, s0, s1, s2, rounding);
+            dest += stride;
+
+            INNERLOOP_YCBCR(dest + 0 * XSTEP, _mm_unpackhi_epi8(y2, zero), cb0, cr0, s0, s1, s2, rounding);
+            INNERLOOP_YCBCR(dest + 1 * XSTEP, _mm_unpackhi_epi8(y3, zero), cb1, cr1, s0, s1, s2, rounding);
+            dest += stride;
+        }
     }
 
+    MANGO_UNREFERENCED(state);
     MANGO_UNREFERENCED(width);
     MANGO_UNREFERENCED(height);
 }
-
-#endif
-
-#ifdef FUNCTION_YCBCR_16x16
 
 void FUNCTION_YCBCR_16x16(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
 {
@@ -192,73 +314,7 @@ void FUNCTION_YCBCR_16x16(u8* dest, size_t stride, const s16* data, ProcessState
     state->idct(result + 256, data + 256, state->block[4].qt); // Cb
     state->idct(result + 320, data + 320, state->block[5].qt); // Cr
 
-    // color conversion
-    const __m128i s0 = JPEG_CONST_SSE2(JPEG_FIXED( 1.00000), JPEG_FIXED( 1.40200));
-    const __m128i s1 = JPEG_CONST_SSE2(JPEG_FIXED( 1.00000), JPEG_FIXED( 1.77200));
-    const __m128i s2 = JPEG_CONST_SSE2(JPEG_FIXED(-0.34414), JPEG_FIXED(-0.71414));
-    const __m128i rounding = _mm_set1_epi32(1 << (JPEG_PREC - 1));
-    const __m128i tosigned = _mm_set1_epi16(128);
-
-    for (int y = 0; y < 4; ++y)
-    {
-        __m128i y0 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 32 + 0));
-        __m128i y1 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 32 + 128));
-        __m128i y2 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 32 + 16));
-        __m128i y3 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 32 + 144));
-        __m128i cb = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 256));
-        __m128i cr = _mm_loadu_si128(reinterpret_cast<const __m128i *>(result + y * 16 + 320));
-
-        __m128i zero = _mm_setzero_si128();
-        __m128i cb0;
-        __m128i cb1;
-        __m128i cr0;
-        __m128i cr1;
-
-        cb0 = _mm_unpacklo_epi8(cb, cb);
-        cr0 = _mm_unpacklo_epi8(cr, cr);
-
-        cb1 = _mm_unpackhi_epi8(cb0, zero);
-        cr1 = _mm_unpackhi_epi8(cr0, zero);
-        cb0 = _mm_unpacklo_epi8(cb0, zero);
-        cr0 = _mm_unpacklo_epi8(cr0, zero);
-
-        cb0 = _mm_sub_epi16(cb0, tosigned);
-        cr0 = _mm_sub_epi16(cr0, tosigned);
-        cb1 = _mm_sub_epi16(cb1, tosigned);
-        cr1 = _mm_sub_epi16(cr1, tosigned);
-
-        INNERLOOP_YCBCR(dest + 0 * XSTEP, _mm_unpacklo_epi8(y0, zero), cb0, cr0, s0, s1, s2, rounding);
-        INNERLOOP_YCBCR(dest + 1 * XSTEP, _mm_unpacklo_epi8(y1, zero), cb1, cr1, s0, s1, s2, rounding);
-        dest += stride;
-
-        INNERLOOP_YCBCR(dest + 0 * XSTEP, _mm_unpackhi_epi8(y0, zero), cb0, cr0, s0, s1, s2, rounding);
-        INNERLOOP_YCBCR(dest + 1 * XSTEP, _mm_unpackhi_epi8(y1, zero), cb1, cr1, s0, s1, s2, rounding);
-        dest += stride;
-
-        cb0 = _mm_unpackhi_epi8(cb, cb);
-        cr0 = _mm_unpackhi_epi8(cr, cr);
-
-        cb1 = _mm_unpackhi_epi8(cb0, zero);
-        cr1 = _mm_unpackhi_epi8(cr0, zero);
-        cb0 = _mm_unpacklo_epi8(cb0, zero);
-        cr0 = _mm_unpacklo_epi8(cr0, zero);
-
-        cb0 = _mm_sub_epi16(cb0, tosigned);
-        cr0 = _mm_sub_epi16(cr0, tosigned);
-        cb1 = _mm_sub_epi16(cb1, tosigned);
-        cr1 = _mm_sub_epi16(cr1, tosigned);
-
-        INNERLOOP_YCBCR(dest + 0 * XSTEP, _mm_unpacklo_epi8(y2, zero), cb0, cr0, s0, s1, s2, rounding);
-        INNERLOOP_YCBCR(dest + 1 * XSTEP, _mm_unpacklo_epi8(y3, zero), cb1, cr1, s0, s1, s2, rounding);
-        dest += stride;
-
-        INNERLOOP_YCBCR(dest + 0 * XSTEP, _mm_unpackhi_epi8(y2, zero), cb0, cr0, s0, s1, s2, rounding);
-        INNERLOOP_YCBCR(dest + 1 * XSTEP, _mm_unpackhi_epi8(y3, zero), cb1, cr1, s0, s1, s2, rounding);
-        dest += stride;
-    }
-
-    MANGO_UNREFERENCED(width);
-    MANGO_UNREFERENCED(height);
+    JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x16)(dest, stride, result, state, width, height, 1, 0);
 }
 
 #endif

--- a/source/mango/jpeg/jpeg_process_sse2.hpp
+++ b/source/mango/jpeg/jpeg_process_sse2.hpp
@@ -52,17 +52,6 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x8)(u8* dest, size_t stride, const u8* spat
     MANGO_UNREFERENCED(height);
 }
 
-void FUNCTION_YCBCR_8x8(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
-{
-    u8 result[64 * 3];
-
-    state->idct(result +   0, data +   0, state->block[0].qt); // Y
-    state->idct(result +  64, data +  64, state->block[1].qt); // Cb
-    state->idct(result + 128, data + 128, state->block[2].qt); // Cr
-
-    JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x8)(dest, stride, result, state, width, height, 1, 0);
-}
-
 #endif
 
 #ifdef FUNCTION_YCBCR_8x16
@@ -119,18 +108,6 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x16)(u8* dest, size_t stride, const u8* spa
     MANGO_UNREFERENCED(state);
     MANGO_UNREFERENCED(width);
     MANGO_UNREFERENCED(height);
-}
-
-void FUNCTION_YCBCR_8x16(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
-{
-    u8 result[64 * 4];
-
-    state->idct(result +   0, data +   0, state->block[0].qt); // Y0
-    state->idct(result +  64, data +  64, state->block[1].qt); // Y1
-    state->idct(result + 128, data + 128, state->block[2].qt); // Cb
-    state->idct(result + 192, data + 192, state->block[3].qt); // Cr
-
-    JPEG_COLOR_FUNC(FUNCTION_YCBCR_8x16)(dest, stride, result, state, width, height, 1, 0);
 }
 
 #endif
@@ -205,18 +182,6 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x8)(u8* dest, size_t stride, const u8* spa
     MANGO_UNREFERENCED(state);
     MANGO_UNREFERENCED(width);
     MANGO_UNREFERENCED(height);
-}
-
-void FUNCTION_YCBCR_16x8(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
-{
-    u8 result[64 * 4];
-
-    state->idct(result +   0, data +   0, state->block[0].qt); // Y0
-    state->idct(result +  64, data +  64, state->block[1].qt); // Y1
-    state->idct(result + 128, data + 128, state->block[2].qt); // Cb
-    state->idct(result + 192, data + 192, state->block[3].qt); // Cr
-
-    JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x8)(dest, stride, result, state, width, height, 1, 0);
 }
 
 #endif
@@ -301,20 +266,6 @@ void JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x16)(u8* dest, size_t stride, const u8* sp
     MANGO_UNREFERENCED(state);
     MANGO_UNREFERENCED(width);
     MANGO_UNREFERENCED(height);
-}
-
-void FUNCTION_YCBCR_16x16(u8* dest, size_t stride, const s16* data, ProcessState* state, int width, int height)
-{
-    u8 result[64 * 6];
-
-    state->idct(result +   0, data +   0, state->block[0].qt); // Y0
-    state->idct(result + 128, data +  64, state->block[1].qt); // Y1
-    state->idct(result +  64, data + 128, state->block[2].qt); // Y2
-    state->idct(result + 192, data + 192, state->block[3].qt); // Y3
-    state->idct(result + 256, data + 256, state->block[4].qt); // Cb
-    state->idct(result + 320, data + 320, state->block[5].qt); // Cr
-
-    JPEG_COLOR_FUNC(FUNCTION_YCBCR_16x16)(dest, stride, result, state, width, height, 1, 0);
 }
 
 #endif

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "mango",
-    "version-string": "3.5.6",
+    "version-string": "3.5.7",
     "description": "Cross-platform C++ image processing and graphics library.",
     "license": "ZLIB",
     "builtin-baseline": "d92484ed3c5020c6679d095ad3e5add907887b62",


### PR DESCRIPTION
Add 256 bit wide iDCT (AVX2).
Add 512 bit wide iDCT (AVX-512).
The iDCT processes number of 8x8 blocks per call.
The Process is split into separate iDCT and color transformation passes.
