### PR TITLE
Refine indexed image decode policy.

### DIFF
--- a/include/mango/image/decoder.hpp
+++ b/include/mango/image/decoder.hpp
@@ -65,6 +65,7 @@ namespace mango::image
         bool    premultiplied = false; // alpha is premultiplied
         bool    linear = false; // linear colorspace (non-linear is sRGB); mirrors color.isLinear()
         bool    alpha = false; // encoded stream carries alpha/transparency (not decode padding)
+        int     palette = 0; // palette color count (0 = no palette)
 
         // Color space signalling (primaries, transfer function, exact chromaticities).
         // Defaults to sRGB: integer image formats are sRGB by near-universal convention,

--- a/include/mango/image/inspect.hpp
+++ b/include/mango/image/inspect.hpp
@@ -64,7 +64,7 @@ namespace mango::image
         InspectTriState progressive = InspectTriState::Unknown;
         ImageTileInfo tiling;
 
-        // Accessible palette entry count (0 = none exposed to client on decode).
+        // Color table size from ImageHeader::palette (0 = none).
         int palette_colors = 0;
     };
 

--- a/source/mango/image/image_gif.cpp
+++ b/source/mango/image/image_gif.cpp
@@ -140,6 +140,7 @@ namespace
         std::unique_ptr<u32[]> canvas;
         std::unique_ptr<u32[]> saved; // snapshot for disposal method 3 (restore to previous)
         bool saved_valid = false;
+        bool animated = false; // frames > 1: keep canvas primed even for indexed frame 0
 
         // Disposal bookkeeping for the previously drawn frame. Disposal happens between
         // frames, so the previous frame's disposal is applied at the start of the next.
@@ -555,6 +556,52 @@ namespace
             }
         }
 
+        // Animated: also prime the RGBA composition canvas so frame 1+ stays correct
+        // after an indexed frame-0 opt-in decode.
+        if (state.animated)
+        {
+            const int screen_w = state.screen_desc.width;
+            const int screen_h = state.screen_desc.height;
+            const size_t canvas_size = size_t(screen_w) * size_t(screen_h);
+
+            if (!canvas_size)
+            {
+                return nullptr;
+            }
+
+            if (!state.canvas)
+            {
+                state.canvas.reset(new u32[canvas_size]);
+                state.saved.reset(new u32[canvas_size]);
+            }
+
+            u32 clear_color = state.transparent_color_flag ? 0 : background_color(state);
+
+            if (state.first_frame)
+            {
+                std::fill_n(state.canvas.get(), canvas_size, clear_color);
+                state.prev_disposal = 0;
+                state.saved_valid = false;
+            }
+
+            if (state.disposal_method == 3)
+            {
+                std::memcpy(state.saved.get(), state.canvas.get(), canvas_size * sizeof(u32));
+                state.saved_valid = true;
+            }
+
+            canvas_composite(state.canvas.get(), screen_w, screen_h, bits.get(),
+                             x, y, width, height,
+                             palette, state.transparent_color_flag != 0, transparent);
+
+            state.prev_disposal = state.disposal_method;
+            state.prev_x = x;
+            state.prev_y = y;
+            state.prev_w = width;
+            state.prev_h = height;
+            state.prev_clear_color = clear_color;
+        }
+
         return data;
     }
 
@@ -808,6 +855,7 @@ namespace
         int frames = 0;
         bool interlaced = false;
         bool alpha = false;
+        int first_local_palette = 0; // used entry count from the first image's local CT
     };
 
     // Walk the GIF data stream (post logical screen descriptor) and collect
@@ -871,7 +919,13 @@ namespace
 
                 if (field & 0x80)
                 {
-                    p += (1 << ((field & 0x07) + 1)) * 3;
+                    const int local_colors = 1 << ((field & 0x07) + 1);
+                    if (info.frames == 0)
+                    {
+                        info.first_local_palette = local_colors;
+                    }
+
+                    p += local_colors * 3;
                 }
 
                 if (p >= end)
@@ -955,6 +1009,24 @@ namespace
                 header.frames  = frames;
                 header.format  = format;
                 header.compression = TextureCompression::NONE;
+                header.alpha = m_metadata.alpha;
+
+                // Color table available for indexed decode (still, or animated frame 0).
+                if (m_state.screen_desc.color_table_flag() && m_state.screen_desc.palette)
+                {
+                    header.palette = m_state.screen_desc.color_table_size();
+                }
+                else if (m_metadata.first_local_palette > 0)
+                {
+                    header.palette = m_metadata.first_local_palette;
+                }
+                else if (format.isIndexed())
+                {
+                    // Decoder synthesizes a grayscale table when none is stored.
+                    header.palette = 256;
+                }
+
+                m_state.animated = frames > 1;
             }
         }
 
@@ -970,13 +1042,6 @@ namespace
             report.encoding = header.frames > 1 ? "GIF LZW (animated)" : "GIF LZW";
             report.bit_depth = 8;
             report.alpha = m_metadata.alpha;
-
-            if (header.format.isIndexed() &&
-                m_state.screen_desc.color_table_flag() &&
-                m_state.screen_desc.palette)
-            {
-                report.palette_colors = m_state.screen_desc.color_table_size();
-            }
         }
 
         ImageDecodeStatus decode(const Surface& dest, const ImageDecodeOptions& options, int level, int depth, int face) override
@@ -993,9 +1058,29 @@ namespace
                 return status;
             }
 
-            DecodeTargetBitmap target(dest, header.width, header.height, header.format);
-
             status.current_frame_index = m_frame_counter;
+
+            if (header.frames > 1 && dest.format.isIndexed())
+            {
+                if (m_frame_counter > 0)
+                {
+                    status.setError("[ImageDecoder.GIF] Animated frame > 0 requires a non-indexed target.");
+                    return status;
+                }
+
+                if (!dest.palette)
+                {
+                    status.setError("[ImageDecoder.GIF] Indexed target requires a non-null palette.");
+                    return status;
+                }
+            }
+
+            // Indexed opt-in uses IndexedFormat even when preferred header.format is RGBA.
+            const Format decode_format = dest.format.isIndexed()
+                ? IndexedFormat(8)
+                : header.format;
+
+            DecodeTargetBitmap target(dest, header.width, header.height, decode_format);
 
             if (m_data)
             {

--- a/source/mango/image/image_iff.cpp
+++ b/source/mango/image/image_iff.cpp
@@ -1174,11 +1174,6 @@ namespace
         void populateInspect(ImageInspect& report) const override
         {
             populateRetroInspect(report, iffEncoding(), iffHasAlpha());
-
-            if (header.format.isIndexed() && m_palette.size > 0)
-            {
-                report.palette_colors = int(m_palette.size);
-            }
         }
 
         const u8* readSignature(const u8* data)
@@ -1536,6 +1531,7 @@ namespace
             if (m_pchg_present && !m_ham && !m_hame && header.success)
             {
                 header.format = Format(32, Format::UNORM, Format::RGBA, 8, 8, 8, 8);
+                header.palette = 0;
             }
         }
 
@@ -1576,6 +1572,7 @@ namespace
                 m_hame_lace = (m_camg & 0x0004) != 0; // interlaced: per-field register sets
                 header.width = planar_w / 2;
                 header.format = Format(32, Format::UNORM, Format::RGBA, 8, 8, 8, 8);
+                header.palette = 0;
             }
         }
 
@@ -1607,6 +1604,7 @@ namespace
                 {
                     case 1:
                         header.format = IndexedFormat(8);
+                        header.palette = int(m_palette.size);
                         break;
                     case 2:
                         header.format = Format(16, Format::UNORM, Format::BGR, 5, 6, 5);

--- a/source/mango/image/image_pcx.cpp
+++ b/source/mango/image/image_pcx.cpp
@@ -186,6 +186,18 @@ namespace
                            : isLuminance ? LuminanceFormat(8, Format::UNORM, 8, 0)
                                          : Format(32, Format::UNORM, Format::RGBA, 8, 8, 8, 8);
             header.compression = TextureCompression::NONE;
+
+            if (isIndexed)
+            {
+                if (isPaletteMarker || (BitsPerPixel == 8 && NPlanes == 1))
+                    header.palette = 256;
+                else if (BitsPerPixel == 4 && NPlanes == 1)
+                    header.palette = 16;
+                else if (BitsPerPixel == 2 && NPlanes == 1)
+                    header.palette = 4;
+                else if (BitsPerPixel == 1 && (NPlanes == 3 || NPlanes == 4))
+                    header.palette = 4;
+            }
         }
 
         ~HeaderPCX()
@@ -447,28 +459,6 @@ namespace
             report.bit_depth = trueColor ? 8 : int(m_pcx_header.BitsPerPixel);
             report.alpha = m_pcx_header.NPlanes == 4;
             report.chroma_subsampling = indexed ? "" : "4:4:4";
-
-            if (header.format.isIndexed())
-            {
-                if (m_pcx_header.isPaletteMarker ||
-                    (m_pcx_header.BitsPerPixel == 8 && m_pcx_header.NPlanes == 1))
-                {
-                    report.palette_colors = 256;
-                }
-                else if (m_pcx_header.BitsPerPixel == 4 && m_pcx_header.NPlanes == 1)
-                {
-                    report.palette_colors = 16;
-                }
-                else if (m_pcx_header.BitsPerPixel == 2 && m_pcx_header.NPlanes == 1)
-                {
-                    report.palette_colors = 4;
-                }
-                else if (m_pcx_header.BitsPerPixel == 1 &&
-                         (m_pcx_header.NPlanes == 3 || m_pcx_header.NPlanes == 4))
-                {
-                    report.palette_colors = 4;
-                }
-            }
         }
 
         ImageDecodeStatus decode(const Surface& dest, const ImageDecodeOptions& options, int level, int depth, int face) override

--- a/source/mango/image/image_png.cpp
+++ b/source/mango/image/image_png.cpp
@@ -2026,6 +2026,10 @@ namespace
         Frame m_frame;
         const u8* m_first_frame = nullptr;
 
+        // APNG composition canvas (RGBA). Kept across frames so indexed frame-0
+        // opt-in can still prime history for later RGBA decodes.
+        std::unique_ptr<Bitmap> m_canvas;
+
         // iCCP
         Buffer m_icc;
 
@@ -2209,7 +2213,11 @@ namespace
                     color_type |= 4;
                 }
 
-                // select decoding format
+                // Preferred decode format. Still images keep native layout (indexed stays
+                // indexed). Animated palette APNG prefers RGBA like GIF: disposal/blend is
+                // not a stable indexed canvas. Other color types keep their native format.
+                const bool animated_palette =
+                    (m_number_of_frames > 1) && (color_type == COLOR_TYPE_PALETTE);
                 int bits = m_color_state.bits <= 8 ? 8 : 16;
                 switch (color_type)
                 {
@@ -2222,7 +2230,9 @@ namespace
                         break;
 
                     case COLOR_TYPE_PALETTE:
-                        m_header.format = IndexedFormat(8, flags);
+                        m_header.format = animated_palette
+                            ? Format(32, Format::UNORM, Format::RGBA, 8, 8, 8, 8, flags)
+                            : IndexedFormat(8, flags);
                         break;
 
                     case COLOR_TYPE_RGB:
@@ -2236,6 +2246,11 @@ namespace
                 m_header.alpha = (m_color_type == COLOR_TYPE_RGBA ||
                                   m_color_type == COLOR_TYPE_IA ||
                                   m_color_state.transparent_enable);
+
+                // Color table for indexed decode (still, or animated frame 0 opt-in).
+                m_header.palette = (m_color_type == COLOR_TYPE_PALETTE)
+                    ? int(m_palette.size)
+                    : 0;
             }
 
             return m_header;
@@ -2298,15 +2313,21 @@ namespace
             // make the animation frame count available from the header (APNG)
             scanAnimationControl();
 
-            // make color space signalling available from the header
+            // make color space signalling + palette available from the header
             scanColorChunks();
+
+            // Indexed-color requires PLTE before IDAT (PNG spec).
+            if (m_header.success && m_color_type == COLOR_TYPE_PALETTE && m_palette.size == 0)
+            {
+                setError("Missing PLTE chunk for indexed-color image.");
+            }
         }
 
         void scanColorChunks()
         {
-            // Pre-scan the ancillary color chunks (all of which must appear before the
-            // first IDAT) so the color space description is available from header() without
-            // having to run the full decode. Does not disturb the decode parsing position.
+            // Pre-scan chunks that must appear before the first IDAT so color space and
+            // palette are available from header()/inspect without a full decode.
+            // Does not disturb the decode parsing position.
             BigEndianConstPointer p = m_pointer;
 
             for ( ; p < m_end - 8; )
@@ -2326,6 +2347,14 @@ namespace
 
                 switch (id)
                 {
+                    case u32_mask_rev('P', 'L', 'T', 'E'):
+                        read_PLTE(p, size);
+                        break;
+
+                    case u32_mask_rev('t', 'R', 'N', 'S'):
+                        read_tRNS(p, size);
+                        break;
+
                     case u32_mask_rev('g', 'A', 'M', 'A'):
                         read_gAMA(p, size);
                         break;
@@ -3852,44 +3881,98 @@ namespace
             return status;
         }
 
-        //
-        // [dest.format]  <--  [m_header.format]
-        //
+        const bool animated = m_number_of_frames > 1;
+        const u32 frame_index = m_next_frame_index;
 
-        DecodeTargetBitmap decode_target(dest, m_width, m_height, m_header.format, m_palette);
-
-        // Set asynchronous update target
-        m_decode_target = &decode_target;
-
-        // Target surface
-        Surface target = decode_target;
-
-        // Temporary animation decoding bitmap
-        std::unique_ptr<Bitmap> temp;
-
-        if (m_number_of_frames > 0)
+        if (animated && dest.format.isIndexed())
         {
-            temp = std::make_unique<Bitmap>(m_frame.width, m_frame.height, m_header.format);
-            target = *temp;
-            m_decode_target = nullptr;
-
-            // compute frame indices (for external users)
-            m_current_frame_index = m_next_frame_index++;
-            if (m_next_frame_index >= m_number_of_frames)
+            if (frame_index > 0)
             {
-                m_next_frame_index = 0;
+                status.setError("[ImageDecoder.PNG] Animated frame > 0 requires a non-indexed target.");
+                return status;
+            }
+
+            if (m_color_type != COLOR_TYPE_PALETTE)
+            {
+                status.setError("[ImageDecoder.PNG] Indexed target requires a palette color type.");
+                return status;
+            }
+
+            if (!dest.palette)
+            {
+                status.setError("[ImageDecoder.PNG] Indexed target requires a non-null palette.");
+                return status;
             }
         }
 
-        Buffer buffer;
+        const bool indexed_frame0 = animated && dest.format.isIndexed() && frame_index == 0;
+
+        // --------------------------------------------------------------------
+        // Still PNG (no acTL)
+        // --------------------------------------------------------------------
+        if (m_number_of_frames == 0)
+        {
+            DecodeTargetBitmap decode_target(dest, m_width, m_height, m_header.format, m_palette);
+            m_decode_target = &decode_target;
+            Surface target = decode_target;
+
+            if (m_interface->cancelled)
+            {
+                return status;
+            }
+
+            const bool plld = m_parallel_height && (m_parallel_flags & 1) != 0;
+
+            if (plld)
+            {
+                decode_plld(target);
+            }
+            else if (m_idot_address && multithread)
+            {
+                decode_idot(target);
+            }
+            else if (!decode_std(target, status))
+            {
+                return status;
+            }
+
+            printLine(Print::Debug, "  filter: {}.{} ms", m_filter_time / 1000, m_filter_time % 1000);
+            printLine(Print::Debug, "  color: {}.{} ms", m_color_time / 1000, m_color_time % 1000);
+
+            status.direct = decode_target.isDirect();
+            return status;
+        }
+
+        // --------------------------------------------------------------------
+        // APNG frame decode into stream-native temp, then composite
+        // --------------------------------------------------------------------
+        const Format canvas_format(32, Format::UNORM, Format::RGBA, 8, 8, 8, 8);
+        const Format stream_format = (m_color_type == COLOR_TYPE_PALETTE)
+            ? IndexedFormat(8)
+            : m_header.format;
+
+        std::unique_ptr<Bitmap> temp =
+            std::make_unique<Bitmap>(m_frame.width, m_frame.height, stream_format);
+        if (temp->palette)
+        {
+            *temp->palette = m_palette;
+        }
+
+        m_decode_target = nullptr;
+        Surface target = *temp;
+
+        m_current_frame_index = m_next_frame_index++;
+        if (m_next_frame_index >= m_number_of_frames)
+        {
+            m_next_frame_index = 0;
+        }
 
         if (m_interface->cancelled)
         {
             return status;
         }
 
-        // The first scanline of segment does not require previous scanline from other segment
-        bool plld = m_parallel_height && (m_parallel_flags & 1) != 0;
+        const bool plld = m_parallel_height && (m_parallel_flags & 1) != 0;
 
         if (plld)
         {
@@ -3899,15 +3982,11 @@ namespace
         {
             decode_idot(target);
         }
-        else
+        else if (!decode_std(target, status))
         {
-            if (!decode_std(target, status))
-            {
-                return status;
-            }
+            return status;
         }
 
-        // These are not wall times; it is cumulative time from all concurrent tasks
         printLine(Print::Debug, "  filter: {}.{} ms", m_filter_time / 1000, m_filter_time % 1000);
         printLine(Print::Debug, "  color: {}.{} ms", m_color_time / 1000, m_color_time % 1000);
 
@@ -3916,41 +3995,104 @@ namespace
             return status;
         }
 
-        if (m_number_of_frames > 0)
+        auto composite_frame = [&](Surface& area)
         {
-            Surface area(dest, m_frame.xoffset, m_frame.yoffset, m_frame.width, m_frame.height);
-
-            if (m_header.format.isIndexed() && !dest.format.isIndexed())
+            if (temp->format.isIndexed())
             {
-                // Compositing indexed APNG frames onto an RGBA canvas: resolve the frame
-                // to RGBA first so we never quantize the destination surface.
                 *temp->palette = m_palette;
-                Bitmap frame_rgba(m_frame.width, m_frame.height,
-                    Format(32, Format::UNORM, Format::RGBA, 8, 8, 8, 8));
+                Bitmap frame_rgba(m_frame.width, m_frame.height, canvas_format);
                 image::resolve(frame_rgba, *temp);
                 blend(area, frame_rgba);
             }
             else
             {
-                TemporaryBitmap bitmap(area, m_header.format);
+                TemporaryBitmap bitmap(area, temp->format);
                 blend(bitmap, *temp);
 
-                if (dest.format != bitmap.format)
+                if (area.format != bitmap.format)
                 {
-                    bitmap.palette = &m_palette;
-                    dest.blit(m_frame.xoffset, m_frame.yoffset, bitmap);
-                }
-                else if (dest.format.isIndexed() && dest.palette)
-                {
-                    *dest.palette = m_palette;
+                    area.blit(0, 0, bitmap);
                 }
             }
+        };
+
+        if (animated)
+        {
+            // Persistent RGBA canvas so indexed frame-0 opt-in still primes history.
+            if (!m_canvas)
+            {
+                m_canvas = std::make_unique<Bitmap>(m_width, m_height, canvas_format);
+                std::memset(m_canvas->image, 0, size_t(m_canvas->stride) * size_t(m_canvas->height));
+            }
+
+            Surface canvas_area(*m_canvas, int(m_frame.xoffset), int(m_frame.yoffset),
+                int(m_frame.width), int(m_frame.height));
+            composite_frame(canvas_area);
+
+            if (indexed_frame0)
+            {
+                for (int y = 0; y < dest.height; ++y)
+                {
+                    std::memset(dest.address<u8>(0, y), 0, size_t(dest.width));
+                }
+
+                for (int y = 0; y < temp->height; ++y)
+                {
+                    const int dy = int(m_frame.yoffset) + y;
+                    if (dy < 0 || dy >= dest.height)
+                    {
+                        continue;
+                    }
+
+                    const u8* src = temp->address<u8>(0, y);
+                    u8* dst = dest.address<u8>(0, dy);
+
+                    for (int x = 0; x < temp->width; ++x)
+                    {
+                        const int dx = int(m_frame.xoffset) + x;
+                        if (dx < 0 || dx >= dest.width)
+                        {
+                            continue;
+                        }
+
+                        const u8 sample = src[x];
+                        if (m_palette[sample].a == 0)
+                        {
+                            continue;
+                        }
+
+                        dst[dx] = sample;
+                    }
+                }
+
+                *dest.palette = m_palette;
+                status.direct = true;
+            }
+            else
+            {
+                DecodeTargetBitmap publish(dest, m_width, m_height, canvas_format);
+                static_cast<Surface&>(publish).blit(0, 0, *m_canvas);
+                publish.resolve();
+                status.direct = publish.isDirect();
+            }
+        }
+        else
+        {
+            // Degenerate single-frame APNG: composite directly into dest.
+            Surface area(dest, int(m_frame.xoffset), int(m_frame.yoffset),
+                int(m_frame.width), int(m_frame.height));
+            composite_frame(area);
+
+            if (dest.format.isIndexed() && dest.palette)
+            {
+                *dest.palette = m_palette;
+            }
+
+            status.direct = false;
         }
 
-        status.current_frame_index = m_current_frame_index;
-        status.next_frame_index = m_next_frame_index;
-
-        status.direct = decode_target.isDirect();
+        status.current_frame_index = int(m_current_frame_index);
+        status.next_frame_index = int(m_next_frame_index);
 
         return status;
     }
@@ -4587,12 +4729,15 @@ namespace
             report.progressive = m_parser.isInterlaced() ? InspectTriState::Yes : InspectTriState::No;
             report.tiling.tiled = InspectTriState::No;
             report.chroma_subsampling = "4:4:4";
-            report.encoding = m_parser.isInterlaced() ? "PNG interlaced" : "PNG";
             report.alpha = header.alpha;
 
-            if (header.format.isIndexed())
+            if (header.frames > 1)
             {
-                report.palette_colors = int(m_parser.paletteSize());
+                report.encoding = m_parser.isInterlaced() ? "APNG interlaced" : "APNG";
+            }
+            else
+            {
+                report.encoding = m_parser.isInterlaced() ? "PNG interlaced" : "PNG";
             }
         }
     };

--- a/source/mango/image/image_tga.cpp
+++ b/source/mango/image/image_tga.cpp
@@ -385,6 +385,10 @@ namespace
                 header.faces   = 0;
                 header.format  = m_targa_header.getFormat();
                 header.compression = TextureCompression::NONE;
+                if (header.format.isIndexed() && m_targa_header.isPalette())
+                {
+                    header.palette = int(m_targa_header.colormap_length);
+                }
             }
             else
             {
@@ -409,11 +413,6 @@ namespace
             report.bit_depth = m_targa_header.pixel_size;
             report.alpha = (m_targa_header.descriptor & DESCRIPTOR_ALPHA) != 0 ||
                            m_targa_header.pixel_size == 32 || m_targa_header.pixel_size == 16;
-
-            if (header.format.isIndexed() && m_targa_header.isPalette())
-            {
-                report.palette_colors = int(m_targa_header.colormap_length);
-            }
         }
 
         ImageDecodeStatus decode(const Surface& surface, const ImageDecodeOptions& options, int level, int depth, int face) override

--- a/source/mango/image/image_tiff.cpp
+++ b/source/mango/image/image_tiff.cpp
@@ -2059,11 +2059,6 @@ namespace
             }
 
             syncHdrInspectFromHeader(report);
-
-            if (header.format.isIndexed() && m_context.palette.size > 0)
-            {
-                report.palette_colors = int(m_context.palette.size);
-            }
         }
 
         bool is_tiled_via_strips() const
@@ -2274,6 +2269,10 @@ namespace
             header.format = getImageFormat();
             header.compression = TextureCompression::NONE;
             header.premultiplied = m_context.associated_alpha;
+            if (header.format.isIndexed() && m_context.palette.size > 0)
+            {
+                header.palette = int(m_context.palette.size);
+            }
 
             // Forward the ICC profile at header() time (decode() also sets it). Color space:
             // integer RGB/grayscale TIFF is sRGB by convention (the default); floating-point

--- a/source/mango/image/inspect.cpp
+++ b/source/mango/image/inspect.cpp
@@ -99,6 +99,7 @@ namespace mango::image
 
             report.bit_depth = formatBitDepth(report.header.format);
             report.alpha = report.header.alpha;
+            report.palette_colors = report.header.palette;
             report.decode_bytes = estimateDecodeBytes(report.header);
 
             populateColorStrings(report, report.header.color, report.header.format);


### PR DESCRIPTION
Sane defaults: animated formats advertise RGBA as decode target format, but still allow indexed decode and palette extraction (less common use case).